### PR TITLE
docs: 修复 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ TapCanvas-pro/
 
 # ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=anymouschina/TapCanvas&type=Date)](https://star-history.com/#anymouschina/TapCanvas&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=anymouschina/TapCanvas&type=Date)](https://star-history.dera.page/#anymouschina/TapCanvas&Date)
 
 ---
 

--- a/apps/agents-cli/skills/evolver/README.md
+++ b/apps/agents-cli/skills/evolver/README.md
@@ -306,7 +306,7 @@ The script automatically detects if compatible local skills (like `skills/feishu
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=autogame-17/evolver&type=Date)](https://star-history.com/#autogame-17/evolver&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=autogame-17/evolver&type=Date)](https://star-history.dera.page/#autogame-17/evolver&Date)
 
 ## Acknowledgments
 

--- a/apps/agents-cli/skills/evolver/README.zh-CN.md
+++ b/apps/agents-cli/skills/evolver/README.zh-CN.md
@@ -250,7 +250,7 @@ MAJOR.MINOR.PATCH
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=autogame-17/evolver&type=Date)](https://star-history.com/#autogame-17/evolver&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=autogame-17/evolver&type=Date)](https://star-history.dera.page/#autogame-17/evolver&Date)
 
 ## 鸣谢
 

--- a/apps/new-api/README.fr.md
+++ b/apps/new-api/README.fr.md
@@ -457,7 +457,7 @@ Si les politiques de votre organisation ne permettent pas l'utilisation de logic
 
 <div align="center">
 
-[![Graphique de l'historique des étoiles](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Graphique de l'historique des étoiles](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/apps/new-api/README.ja.md
+++ b/apps/new-api/README.ja.md
@@ -457,7 +457,7 @@ docker run --name new-api -d --restart always \
 
 <div align="center">
 
-[![スター履歴チャート](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![スター履歴チャート](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/apps/new-api/README.md
+++ b/apps/new-api/README.md
@@ -465,7 +465,7 @@ If your organization's policies do not permit the use of AGPLv3-licensed softwar
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/apps/new-api/README.zh_CN.md
+++ b/apps/new-api/README.zh_CN.md
@@ -462,7 +462,7 @@ docker run --name new-api -d --restart always \
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/apps/new-api/README.zh_TW.md
+++ b/apps/new-api/README.zh_TW.md
@@ -457,7 +457,7 @@ docker run --name new-api -d --restart always \
 
 <div align="center">
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.com/#Calcium-Ion/new-api&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Calcium-Ion/new-api&type=Date)](https://star-history.dera.page/#Calcium-Ion/new-api&Date)
 
 </div>
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -957,7 +957,7 @@ MIT License
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=anymouschina/TapCanvas&type=Date)](https://star-history.com/#anymouschina/TapCanvas&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=anymouschina/TapCanvas&type=Date)](https://star-history.dera.page/#anymouschina/TapCanvas&Date)
 
 ---
 


### PR DESCRIPTION
当前 README 中的 Star History 图表已无法正常渲染，原因是上游数据源访问受限，导致图表请求失败，社区用户无法看到项目 Star 增长趋势。

本 PR 将各 README 中的 Star History 图表链接更新为可正常工作的服务，恢复图表显示。改动仅限 README 中的链接，不影响任何功能。