### PR TITLE
test(agents-cli): add unit tests for http-server bridge and cli args

### DIFF
--- a/apps/agents-cli/src/bridge/http-server.test.ts
+++ b/apps/agents-cli/src/bridge/http-server.test.ts
@@ -1,0 +1,141 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { IncomingMessage, ServerResponse } from "node:http";
+
+import { BridgeRequestError } from "./contracts.js";
+import {
+  authorize,
+  errorDetails,
+  requiredBodyString,
+  SseWriter,
+  SessionSerialGate,
+} from "./http-server.js";
+
+function fakeIncoming(headers: Record<string, string | undefined> = {}): IncomingMessage {
+  return { headers } as unknown as IncomingMessage;
+}
+
+function fakeResponse(): { chunks: string[]; writableEnded: boolean } & ServerResponse {
+  const state = { chunks: [] as string[], writableEnded: false };
+  const response = {
+    get chunks() {
+      return state.chunks;
+    },
+    get writableEnded() {
+      return state.writableEnded;
+    },
+    write(frame: string): boolean {
+      state.chunks.push(frame);
+      return true;
+    },
+    end(): void {
+      state.writableEnded = true;
+    },
+  } as unknown as { chunks: string[]; writableEnded: boolean } & ServerResponse;
+  return response;
+}
+
+test("authorize allows every request when no token is configured", () => {
+  assert.equal(authorize(fakeIncoming(), undefined), true);
+});
+
+test("authorize accepts a matching Bearer token", () => {
+  assert.equal(authorize(fakeIncoming({ authorization: "Bearer secret" }), "secret"), true);
+});
+
+test("authorize accepts a matching x-agents-token header", () => {
+  assert.equal(authorize(fakeIncoming({ "x-agents-token": "secret" }), "secret"), true);
+});
+
+test("authorize rejects a mismatched token", () => {
+  assert.equal(authorize(fakeIncoming({ authorization: "Bearer wrong" }), "secret"), false);
+});
+
+test("authorize rejects a missing token when one is configured", () => {
+  assert.equal(authorize(fakeIncoming(), "secret"), false);
+});
+
+test("errorDetails maps a BridgeRequestError to its own status and code", () => {
+  assert.deepEqual(errorDetails(new BridgeRequestError("bad thing", "bad_thing", 422)), {
+    status: 422,
+    code: "bad_thing",
+    message: "bad thing",
+  });
+});
+
+test("errorDetails maps JSON syntax errors to 400 invalid_json", () => {
+  assert.deepEqual(errorDetails(new SyntaxError("bad json")), {
+    status: 400,
+    code: "invalid_json",
+    message: "bad json",
+  });
+});
+
+test("errorDetails maps unknown errors to a generic 500", () => {
+  assert.deepEqual(errorDetails(new Error("boom")), {
+    status: 500,
+    code: "deepseek_harness_bridge_failed",
+    message: "boom",
+  });
+});
+
+test("requiredBodyString returns the trimmed non-empty value", () => {
+  assert.equal(requiredBodyString({ userId: "  user-1  " }, "userId"), "user-1");
+});
+
+test("requiredBodyString rejects a non-object body", () => {
+  assert.throws(() => requiredBodyString("nope", "userId"), BridgeRequestError);
+});
+
+test("requiredBodyString rejects a missing or blank key", () => {
+  assert.throws(() => requiredBodyString({}, "userId"), BridgeRequestError);
+  assert.throws(() => requiredBodyString({ userId: "   " }, "userId"), BridgeRequestError);
+});
+
+test("SessionSerialGate serializes tasks sharing the same key", async () => {
+  const gate = new SessionSerialGate();
+  const order: string[] = [];
+  const first = gate.run("k", async () => {
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    order.push("first");
+  });
+  const second = gate.run("k", async () => {
+    order.push("second");
+  });
+  await Promise.all([first, second]);
+  assert.deepEqual(order, ["first", "second"]);
+});
+
+test("SessionSerialGate runs distinct keys concurrently", async () => {
+  const gate = new SessionSerialGate();
+  let running = 0;
+  let peak = 0;
+  const keys = ["a", "b", "c"];
+  const task = (key: string) =>
+    gate.run(key, async () => {
+      running += 1;
+      peak = Math.max(peak, running);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      running -= 1;
+    });
+  await Promise.all(keys.map((key) => task(key)));
+  assert.ok(peak >= 2, `expected concurrent execution, peak was ${peak}`);
+});
+
+test("SseWriter emits a single SSE frame in the expected format", async () => {
+  const response = fakeResponse();
+  const writer = new SseWriter(response);
+  writer.emit({ event: "delta", data: { text: "hi" } });
+  await writer.finish();
+  assert.deepEqual(response.chunks, ['event: delta\ndata: {"text":"hi"}\n\n']);
+  assert.equal(response.writableEnded, true);
+});
+
+test("SseWriter ignores emits after stop", async () => {
+  const response = fakeResponse();
+  const writer = new SseWriter(response);
+  writer.stop();
+  writer.emit({ event: "delta", data: { text: "hi" } });
+  await writer.finish();
+  assert.deepEqual(response.chunks, []);
+});

--- a/apps/agents-cli/src/bridge/http-server.ts
+++ b/apps/agents-cli/src/bridge/http-server.ts
@@ -27,7 +27,7 @@ export type HarnessHttpServer = Readonly<{
 
 class BodyLimitError extends Error {}
 
-class SseWriter {
+export class SseWriter {
   private queue: Promise<void> = Promise.resolve();
   private closed = false;
 
@@ -53,7 +53,7 @@ class SseWriter {
   }
 }
 
-class SessionSerialGate {
+export class SessionSerialGate {
   private readonly tails = new Map<string, Promise<unknown>>();
 
   async run<T>(key: string, task: () => Promise<T>): Promise<T> {
@@ -68,7 +68,7 @@ class SessionSerialGate {
   }
 }
 
-function authorize(request: IncomingMessage, token: string | undefined): boolean {
+export function authorize(request: IncomingMessage, token: string | undefined): boolean {
   if (!token) return true;
   const authorization = request.headers.authorization;
   const agentsToken = request.headers["x-agents-token"];
@@ -109,7 +109,7 @@ function beginSse(response: ServerResponse): void {
   response.flushHeaders();
 }
 
-function errorDetails(error: unknown): { status: number; code: string; message: string } {
+export function errorDetails(error: unknown): { status: number; code: string; message: string } {
   if (error instanceof BridgeRequestError) {
     return { status: error.status, code: error.code, message: error.message };
   }
@@ -140,7 +140,7 @@ function combineAbortSignals(signals: readonly AbortSignal[]): AbortSignal {
   return AbortSignal.any([...signals]);
 }
 
-function requiredBodyString(body: unknown, key: string): string {
+export function requiredBodyString(body: unknown, key: string): string {
   if (!body || typeof body !== "object" || Array.isArray(body)) {
     throw new BridgeRequestError("request body must be a JSON object", "invalid_request_body");
   }

--- a/apps/agents-cli/src/cli/args.test.ts
+++ b/apps/agents-cli/src/cli/args.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { positiveInteger } from "./args.js";
+
+test("positiveInteger parses a positive integer", () => {
+  assert.equal(positiveInteger("8000000", "body-limit"), 8000000);
+  assert.equal(positiveInteger("8799", "port"), 8799);
+});
+
+test("positiveInteger rejects zero and negative values", () => {
+  assert.throws(() => positiveInteger("0", "port"), /必须是正整数/);
+  assert.throws(() => positiveInteger("-1", "port"), /必须是正整数/);
+});
+
+test("positiveInteger rejects non-numeric and fractional input", () => {
+  assert.throws(() => positiveInteger("abc", "port"), /必须是正整数/);
+  assert.throws(() => positiveInteger("1.5", "port"), /必须是正整数/);
+});

--- a/apps/agents-cli/src/cli/args.ts
+++ b/apps/agents-cli/src/cli/args.ts
@@ -1,0 +1,7 @@
+export function positiveInteger(value: string, label: string): number {
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${label} 必须是正整数，收到：${value}`);
+  }
+  return parsed;
+}

--- a/apps/agents-cli/src/cli/index.ts
+++ b/apps/agents-cli/src/cli/index.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 
 import { startHarnessHttpServer } from "../bridge/http-server.js";
+import { positiveInteger } from "./args.js";
 
 type ServeOptions = Readonly<{
   host: string;
@@ -9,14 +10,6 @@ type ServeOptions = Readonly<{
   token?: string;
   bodyLimit: string;
 }>;
-
-function positiveInteger(value: string, label: string): number {
-  const parsed = Number(value);
-  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`${label} 必须是正整数，收到：${value}`);
-  }
-  return parsed;
-}
 
 const program = new Command();
 


### PR DESCRIPTION
Add unit tests covering authorize, errorDetails, requiredBodyString, SessionSerialGate, SseWriter, and positiveInteger. Export internal symbols and extract positiveInteger to args.ts to enable testing. No behavior change.