### PR TITLE
feat(gaisc): complete GPT Image 2 request validation

### DIFF
--- a/apps/new-api/dto/openai_image.go
+++ b/apps/new-api/dto/openai_image.go
@@ -41,16 +41,17 @@ type ImageRequest struct {
 	Extra map[string]json.RawMessage `json:"-"`
 }
 
-// ImageURLReference is the JSON image reference shape accepted by the G-AISC
-// image edit endpoint. It is deliberately typed so the gateway preserves the
-// images[].image_url and mask.image_url contract without semantic guessing.
+// ImageURLReference is the JSON image reference shape accepted by OpenAI-style
+// JSON image edit endpoints. A reference must contain exactly one of image_url
+// or file_id. Legacy string inputs are normalized to image_url references.
 type ImageURLReference struct {
-	ImageURL string `json:"image_url"`
+	ImageURL string `json:"image_url,omitempty"`
+	FileID   string `json:"file_id,omitempty"`
 }
 
 // UnmarshalJSON accepts both the canonical G-AISC object shape and the legacy
 // string-array shape used by existing callers. MarshalJSON remains canonical:
-// every reference is emitted as {"image_url":"..."}.
+// every legacy string reference is emitted as {"image_url":"..."}.
 func (reference *ImageURLReference) UnmarshalJSON(data []byte) error {
 	var imageURL string
 	if err := common.Unmarshal(data, &imageURL); err == nil {
@@ -58,7 +59,7 @@ func (reference *ImageURLReference) UnmarshalJSON(data []byte) error {
 		if imageURL == "" {
 			return errors.New("image URL must not be empty")
 		}
-		reference.ImageURL = imageURL
+		*reference = ImageURLReference{ImageURL: imageURL}
 		return nil
 	}
 
@@ -68,10 +69,24 @@ func (reference *ImageURLReference) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	object.ImageURL = strings.TrimSpace(object.ImageURL)
-	if object.ImageURL == "" {
-		return errors.New("image_url must not be empty")
+	object.FileID = strings.TrimSpace(object.FileID)
+	parsed := ImageURLReference(object)
+	if err := parsed.Validate(); err != nil {
+		return err
 	}
-	*reference = ImageURLReference(object)
+	*reference = parsed
+	return nil
+}
+
+// Validate enforces the official JSON edit reference union. It is also used by
+// relays because callers may construct ImageRequest values without JSON
+// unmarshalling first.
+func (reference ImageURLReference) Validate() error {
+	hasImageURL := strings.TrimSpace(reference.ImageURL) != ""
+	hasFileID := strings.TrimSpace(reference.FileID) != ""
+	if hasImageURL == hasFileID {
+		return errors.New("image reference must provide exactly one of image_url or file_id")
+	}
 	return nil
 }
 

--- a/apps/new-api/dto/openai_image_test.go
+++ b/apps/new-api/dto/openai_image_test.go
@@ -93,6 +93,42 @@ func TestImageRequestAcceptsStringEditReferencesAndMarshalsCanonicalShape(t *tes
 	require.JSONEq(t, `{"image_url":"https://example.com/mask.png"}`, string(payload["mask"]))
 }
 
+func TestImageRequestAcceptsFileIDEditReferences(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"model":"gpt-image-2",
+		"prompt":"replace the background",
+		"images":[{"file_id":"file-source"}],
+		"mask":{"file_id":"file-mask"}
+	}`)
+
+	var request ImageRequest
+	require.NoError(t, common.Unmarshal(raw, &request))
+	require.Equal(t, []ImageURLReference{{FileID: "file-source"}}, request.Images)
+	require.Equal(t, &ImageURLReference{FileID: "file-mask"}, request.Mask)
+
+	encoded, err := common.Marshal(request)
+	require.NoError(t, err)
+	var payload map[string]json.RawMessage
+	require.NoError(t, common.Unmarshal(encoded, &payload))
+	require.JSONEq(t, `[{"file_id":"file-source"}]`, string(payload["images"]))
+	require.JSONEq(t, `{"file_id":"file-mask"}`, string(payload["mask"]))
+}
+
+func TestImageRequestRejectsInvalidReferenceUnion(t *testing.T) {
+	t.Parallel()
+
+	for _, raw := range []string{
+		`{"model":"gpt-image-2","prompt":"test","images":[{}]}`,
+		`{"model":"gpt-image-2","prompt":"test","images":[{"image_url":"https://example.com/a.png","file_id":"file-a"}]}`,
+		`{"model":"gpt-image-2","prompt":"test","mask":{}}`,
+	} {
+		var request ImageRequest
+		require.ErrorContains(t, common.Unmarshal([]byte(raw), &request), "exactly one of image_url or file_id")
+	}
+}
+
 func TestValidateGptImage2Size(t *testing.T) {
 	t.Parallel()
 

--- a/apps/new-api/relay/channel/openai/adaptor.go
+++ b/apps/new-api/relay/channel/openai/adaptor.go
@@ -657,7 +657,167 @@ func normalizeGaiscImageRequest(request dto.ImageRequest) (dto.ImageRequest, err
 	if strings.TrimSpace(request.ResponseFormat) == "" {
 		request.ResponseFormat = "url"
 	}
+	if err := validateGaiscImageOptions(request); err != nil {
+		return request, err
+	}
 	return request, nil
+}
+
+func validateGaiscImageOptions(request dto.ImageRequest) error {
+	if strings.TrimSpace(request.Prompt) == "" {
+		return errors.New("gpt-image-2 prompt is required")
+	}
+	if request.N != nil && (*request.N < 1 || *request.N > 10) {
+		return errors.New("gpt-image-2 n must be between 1 and 10")
+	}
+	if err := validateOptionalString("quality", request.Quality, "auto", "low", "medium", "high"); err != nil {
+		return err
+	}
+	if err := validateOptionalString("response_format", request.ResponseFormat, "url", "b64_json"); err != nil {
+		return err
+	}
+	background, hasBackground, err := rawOptionalString("background", request.Background)
+	if err != nil {
+		return err
+	}
+	if hasBackground {
+		if err := validateOptionalString("background", background, "auto", "transparent", "opaque"); err != nil {
+			return err
+		}
+	}
+	outputFormat, hasOutputFormat, err := rawOptionalString("output_format", request.OutputFormat)
+	if err != nil {
+		return err
+	}
+	if hasOutputFormat {
+		if err := validateOptionalString("output_format", outputFormat, "png", "jpeg", "webp"); err != nil {
+			return err
+		}
+	}
+	if hasBackground && background == "transparent" && hasOutputFormat && outputFormat == "jpeg" {
+		return errors.New("gpt-image-2 transparent background requires output_format png or webp")
+	}
+	if err := validateRawString("moderation", request.Moderation, "auto", "low"); err != nil {
+		return err
+	}
+	if err := validateRawIntegerRange("output_compression", request.OutputCompression, 0, 100); err != nil {
+		return err
+	}
+	if len(request.OutputCompression) > 0 && (!hasOutputFormat || outputFormat == "png") {
+		return errors.New("gpt-image-2 output_compression requires output_format jpeg or webp")
+	}
+	partialImages, hasPartialImages, err := rawOptionalInteger("partial_images", request.PartialImages)
+	if err != nil {
+		return err
+	}
+	if hasPartialImages && (partialImages < 0 || partialImages > 3) {
+		return errors.New("gpt-image-2 partial_images must be between 0 and 3")
+	}
+	stream, hasStream, err := rawOptionalBoolean("stream", request.Extra["stream"])
+	if err != nil {
+		return err
+	}
+	if hasPartialImages && partialImages > 0 && (!hasStream || !stream) {
+		return errors.New("gpt-image-2 partial_images greater than 0 requires stream=true")
+	}
+	if len(request.User) > 0 {
+		var user string
+		if err := common.Unmarshal(request.User, &user); err != nil {
+			return errors.New("gpt-image-2 user must be a string")
+		}
+	}
+	inputFidelity, hasInputFidelity, err := rawOptionalString("input_fidelity", request.Extra["input_fidelity"])
+	if err != nil {
+		return err
+	}
+	if hasInputFidelity && inputFidelity != "high" {
+		return errors.New("gpt-image-2 input_fidelity must be high")
+	}
+	if hasInputFidelity && len(request.Images) == 0 {
+		return errors.New("gpt-image-2 input_fidelity requires at least one image")
+	}
+	if len(request.Images) > 16 {
+		return errors.New("gpt-image-2 images must not exceed 16")
+	}
+	for index, reference := range request.Images {
+		if err := reference.Validate(); err != nil {
+			return fmt.Errorf("gpt-image-2 images[%d]: %w", index, err)
+		}
+	}
+	if request.Mask != nil && len(request.Images) == 0 {
+		return errors.New("gpt-image-2 mask requires at least one image")
+	}
+	if request.Mask != nil {
+		if err := request.Mask.Validate(); err != nil {
+			return fmt.Errorf("gpt-image-2 mask: %w", err)
+		}
+	}
+	return nil
+}
+
+func validateOptionalString(field, value string, allowed ...string) error {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "" {
+		return nil
+	}
+	for _, candidate := range allowed {
+		if value == candidate {
+			return nil
+		}
+	}
+	return fmt.Errorf("gpt-image-2 %s must be one of %s", field, strings.Join(allowed, ", "))
+}
+
+func validateRawString(field string, raw json.RawMessage, allowed ...string) error {
+	value, ok, err := rawOptionalString(field, raw)
+	if err != nil || !ok {
+		return err
+	}
+	return validateOptionalString(field, value, allowed...)
+}
+
+func rawOptionalString(field string, raw json.RawMessage) (string, bool, error) {
+	if len(raw) == 0 {
+		return "", false, nil
+	}
+	var value string
+	if err := common.Unmarshal(raw, &value); err != nil {
+		return "", false, fmt.Errorf("gpt-image-2 %s must be a string", field)
+	}
+	return strings.ToLower(strings.TrimSpace(value)), true, nil
+}
+
+func validateRawIntegerRange(field string, raw json.RawMessage, minValue, maxValue int) error {
+	value, ok, err := rawOptionalInteger(field, raw)
+	if err != nil || !ok {
+		return err
+	}
+	if value < minValue || value > maxValue {
+		return fmt.Errorf("gpt-image-2 %s must be between %d and %d", field, minValue, maxValue)
+	}
+	return nil
+}
+
+func rawOptionalInteger(field string, raw json.RawMessage) (int, bool, error) {
+	if len(raw) == 0 {
+		return 0, false, nil
+	}
+	var value int
+	if err := common.Unmarshal(raw, &value); err != nil {
+		return 0, false, fmt.Errorf("gpt-image-2 %s must be an integer", field)
+	}
+	return value, true, nil
+}
+
+func rawOptionalBoolean(field string, raw json.RawMessage) (bool, bool, error) {
+	if len(raw) == 0 {
+		return false, false, nil
+	}
+	var value bool
+	if err := common.Unmarshal(raw, &value); err != nil {
+		return false, false, fmt.Errorf("gpt-image-2 %s must be a boolean", field)
+	}
+	return value, true, nil
 }
 
 func stripGaiscImageTransportAliases(request dto.ImageRequest) (dto.ImageRequest, error) {

--- a/apps/new-api/relay/channel/openai/adaptor_image_test.go
+++ b/apps/new-api/relay/channel/openai/adaptor_image_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/dto"
 	relaycommon "github.com/QuantumNous/new-api/relay/common"
@@ -136,6 +137,129 @@ func TestConvertGaiscGenerationCanonicalizesRatioAliases(t *testing.T) {
 	require.Equal(t, "/v1/images/generations", info.RequestURLPath)
 	require.NotContains(t, convertedRequest.Extra, "aspect_ratio")
 	require.NotContains(t, convertedRequest.Extra, "resolution")
+}
+
+func TestConvertGaiscGenerationPreservesOfficialOptionalParameters(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`{
+		"model":"gpt-image-2",
+		"prompt":"preserve every official image option",
+		"n":1,
+		"size":"1024x1024",
+		"quality":"high",
+		"response_format":"url",
+		"background":"transparent",
+		"output_format":"webp",
+		"output_compression":0,
+		"partial_images":0,
+		"moderation":"low",
+		"input_fidelity":"high",
+		"images":[{"image_url":"https://example.com/input.png"}],
+		"stream":false,
+		"user":"customer-42"
+	}`)
+	var request dto.ImageRequest
+	require.NoError(t, common.Unmarshal(raw, &request))
+
+	context := newImageEditJSONTestContext()
+	context.Request.URL.Path = "/v1/images/generations"
+	info := newImageRelayInfo(constant.ChannelTypeGaiscImage, relayconstant.RelayModeImagesGenerations)
+
+	converted, err := (&Adaptor{}).ConvertImageRequest(context, info, request)
+	require.NoError(t, err)
+	encoded, err := common.Marshal(converted)
+	require.NoError(t, err)
+
+	var payload map[string]json.RawMessage
+	require.NoError(t, common.Unmarshal(encoded, &payload))
+	for _, field := range []string{
+		"n", "size", "quality", "response_format", "background",
+		"output_format", "output_compression", "partial_images",
+		"moderation", "stream", "user",
+		"input_fidelity",
+	} {
+		require.Contains(t, payload, field)
+	}
+	require.JSONEq(t, `0`, string(payload["output_compression"]))
+	require.JSONEq(t, `0`, string(payload["partial_images"]))
+	require.JSONEq(t, `false`, string(payload["stream"]))
+}
+
+func TestConvertGaiscGenerationRejectsInvalidParameterConstraints(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "n", raw: `{"model":"gpt-image-2","prompt":"test","n":11}`, want: "n must be between 1 and 10"},
+		{name: "quality", raw: `{"model":"gpt-image-2","prompt":"test","quality":"ultra"}`, want: "quality must be one of"},
+		{name: "compression", raw: `{"model":"gpt-image-2","prompt":"test","output_compression":101}`, want: "output_compression must be between 0 and 100"},
+		{name: "compression_without_lossy_format", raw: `{"model":"gpt-image-2","prompt":"test","output_compression":80}`, want: "requires output_format jpeg or webp"},
+		{name: "transparent_jpeg", raw: `{"model":"gpt-image-2","prompt":"test","background":"transparent","output_format":"jpeg"}`, want: "requires output_format png or webp"},
+		{name: "partial_without_stream", raw: `{"model":"gpt-image-2","prompt":"test","partial_images":1,"stream":false}`, want: "requires stream=true"},
+		{name: "input_fidelity_without_image", raw: `{"model":"gpt-image-2","prompt":"test","input_fidelity":"high"}`, want: "requires at least one image"},
+		{name: "mask_without_image", raw: `{"model":"gpt-image-2","prompt":"test","mask":{"image_url":"https://example.com/mask.png"}}`, want: "mask requires at least one image"},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var request dto.ImageRequest
+			require.NoError(t, common.Unmarshal([]byte(test.raw), &request))
+			context := newImageEditJSONTestContext()
+			context.Request.URL.Path = "/v1/images/generations"
+			info := newImageRelayInfo(constant.ChannelTypeGaiscImage, relayconstant.RelayModeImagesGenerations)
+			_, err := (&Adaptor{}).ConvertImageRequest(context, info, request)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestConvertGaiscGenerationAcceptsOfficialMaximumCountAndOptionalCompression(t *testing.T) {
+	t.Parallel()
+
+	var request dto.ImageRequest
+	require.NoError(t, common.Unmarshal([]byte(`{
+		"model":"gpt-image-2",
+		"prompt":"ten variations",
+		"n":10,
+		"output_format":"webp"
+	}`), &request))
+	context := newImageEditJSONTestContext()
+	context.Request.URL.Path = "/v1/images/generations"
+	info := newImageRelayInfo(constant.ChannelTypeGaiscImage, relayconstant.RelayModeImagesGenerations)
+
+	converted, err := (&Adaptor{}).ConvertImageRequest(context, info, request)
+	require.NoError(t, err)
+	encoded, err := common.Marshal(converted)
+	require.NoError(t, err)
+	var payload map[string]json.RawMessage
+	require.NoError(t, common.Unmarshal(encoded, &payload))
+	require.JSONEq(t, `10`, string(payload["n"]))
+	require.NotContains(t, payload, "output_compression")
+}
+
+func TestConvertGaiscJSONEditPreservesFileIDReferences(t *testing.T) {
+	t.Parallel()
+
+	var request dto.ImageRequest
+	require.NoError(t, common.Unmarshal([]byte(`{
+		"model":"gpt-image-2",
+		"prompt":"edit uploaded image",
+		"images":[{"file_id":"file-source"}],
+		"mask":{"file_id":"file-mask"}
+	}`), &request))
+	context := newImageEditJSONTestContext()
+	info := newImageRelayInfo(constant.ChannelTypeGaiscImage, relayconstant.RelayModeImagesEdits)
+
+	converted, err := (&Adaptor{}).ConvertImageRequest(context, info, request)
+	require.NoError(t, err)
+	encoded, err := common.Marshal(converted)
+	require.NoError(t, err)
+	var payload map[string]json.RawMessage
+	require.NoError(t, common.Unmarshal(encoded, &payload))
+	require.JSONEq(t, `[{"file_id":"file-source"}]`, string(payload["images"]))
+	require.JSONEq(t, `{"file_id":"file-mask"}`, string(payload["mask"]))
 }
 
 func TestConvertGaiscGenerationRoutesReferenceImagesToJSONEdit(t *testing.T) {


### PR DESCRIPTION
## 变更描述

补全现有 G-AISC `gpt-image-2` 渠道的官方请求参数与前置校验：

- 图片与 mask 引用支持 `image_url` / `file_id` 二选一，并继续兼容旧字符串 URL 输入
- 校验 `n`、`quality`、`background`、`output_format`、`moderation`、`output_compression`、`partial_images` 和 `input_fidelity`
- 校验透明背景、压缩格式、流式部分图、mask 和输入图片之间的条件约束
- 保留客户端显式传入的 `0` 与 `false`，避免转发时静默丢失
- 为合法边界和非法组合补充回归测试

该 PR 只修改已有 G-AISC/OpenAI 图片协议代码，不包含 Fairy 私有定价、模型映射、部署文件或供应商凭据。

## 变更类型

- [x] 新功能
- [x] Bug 修复

## 验证

```text
go test -count=1 ./dto ./relay/channel/openai
ok github.com/QuantumNous/new-api/dto
ok github.com/QuantumNous/new-api/relay/channel/openai
```
