### PR TITLE
fix(pricing): expand duration min/max/step ranges

### DIFF
--- a/apps/new-api/model/pricing.go
+++ b/apps/new-api/model/pricing.go
@@ -1,7 +1,6 @@
 package model
 
 import (
-	"encoding/json"
 	"fmt"
 	"math"
 	"sort"
@@ -806,12 +805,39 @@ func effectivePublishedBasePriceCNYFrom(
 	return fixedImageBasePriceCNY(modelName)
 }
 
+const maxExpandedDurationOptions = 3600
+
+func positiveIntegerParam(value any) (int, bool) {
+	maxInt := int(^uint(0) >> 1)
+	switch typed := value.(type) {
+	case float64:
+		if typed <= 0 || typed >= float64(maxInt) || math.Trunc(typed) != typed {
+			return 0, false
+		}
+		return int(typed), true
+	case int:
+		return typed, typed > 0
+	case int64:
+		if typed <= 0 || uint64(typed) > uint64(maxInt) {
+			return 0, false
+		}
+		return int(typed), true
+	case uint:
+		if typed == 0 || typed > uint(maxInt) {
+			return 0, false
+		}
+		return int(typed), true
+	default:
+		return 0, false
+	}
+}
+
 func extractDurationOptions(meta *Model) []int {
 	if meta == nil || strings.TrimSpace(meta.ParamsDef) == "" {
 		return nil
 	}
 	var raw []map[string]any
-	if err := json.Unmarshal([]byte(meta.ParamsDef), &raw); err != nil {
+	if err := common.Unmarshal([]byte(meta.ParamsDef), &raw); err != nil {
 		return nil
 	}
 	for _, item := range raw {
@@ -830,20 +856,38 @@ func extractDurationOptions(meta *Model) []int {
 			if !ok {
 				continue
 			}
-			switch typed := value.(type) {
-			case float64:
-				if typed > 0 && math.Trunc(typed) == typed {
-					out = append(out, int(typed))
-				}
-			case int:
-				if typed > 0 {
-					out = append(out, typed)
-				}
+			if duration, valid := positiveIntegerParam(value); valid {
+				out = append(out, duration)
 			}
 		}
 		if len(out) > 0 {
 			return out
 		}
+		minDuration, hasMin := positiveIntegerParam(item["min"])
+		maxDuration, hasMax := positiveIntegerParam(item["max"])
+		if !hasMin || !hasMax || minDuration > maxDuration {
+			return nil
+		}
+		step := 1
+		if rawStep, exists := item["step"]; exists {
+			parsedStep, valid := positiveIntegerParam(rawStep)
+			if !valid {
+				return nil
+			}
+			step = parsedStep
+		}
+		count := ((maxDuration - minDuration) / step) + 1
+		if count > maxExpandedDurationOptions {
+			return nil
+		}
+		out = make([]int, 0, count)
+		for duration := minDuration; duration <= maxDuration; duration += step {
+			out = append(out, duration)
+			if duration > maxDuration-step {
+				break
+			}
+		}
+		return out
 	}
 	return nil
 }

--- a/apps/new-api/model/pricing_test.go
+++ b/apps/new-api/model/pricing_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"math"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -443,6 +444,32 @@ func TestBuildParamPricingForSeedance(t *testing.T) {
 	assertSpecPriceCNY("video:720p:6s", 1.7100*6)
 	assertSpecPriceCNY("video:1080p:4s", 3.8544*4)
 	assertSpecPriceCNY("video:1080p:6s", 3.8544*6)
+}
+
+func TestExtractDurationOptionsExpandsIntegerRanges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want []int
+	}{
+		{name: "default step", raw: `[{"key":"duration","type":"integer","min":3,"max":6}]`, want: []int{3, 4, 5, 6}},
+		{name: "explicit step", raw: `[{"key":"duration","type":"integer","min":4,"max":10,"step":2}]`, want: []int{4, 6, 8, 10}},
+		{name: "invalid descending range", raw: `[{"key":"duration","type":"integer","min":10,"max":4,"step":1}]`, want: nil},
+		{name: "invalid zero step", raw: `[{"key":"duration","type":"integer","min":4,"max":10,"step":0}]`, want: nil},
+		{name: "expansion guard", raw: `[{"key":"duration","type":"integer","min":1,"max":5000,"step":1}]`, want: nil},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := extractDurationOptions(&Model{ParamsDef: test.raw})
+			if !slices.Equal(got, test.want) {
+				t.Fatalf("extractDurationOptions() = %v, want %v", got, test.want)
+			}
+		})
+	}
 }
 
 func TestBuildParamPricingExplicitDisableDoesNotRestoreSystemDefault(t *testing.T) {


### PR DESCRIPTION
## 变更描述

价格目录此前只会读取 `duration.options` 枚举。模型若使用更紧凑的整数范围定义（`min` / `max` / `step`），`param_pricing` 不会生成任何按时长规格。

本 PR：

- 保留既有枚举行为
- 支持展开整数 `min` / `max` / `step`，未提供 `step` 时默认为 1
- 拒绝非正数、倒序范围和非法步长
- 限制最多展开 3600 个选项，避免异常目录造成过量分配
- 使用项目统一的 `common.Unmarshal`
- 补充默认步长、显式步长和非法范围测试

不包含任何 Fairy 模型、供应商价格或部署数据。

## 变更类型

- [x] Bug 修复

## 验证

```text
go test -count=1 ./model
ok github.com/QuantumNous/new-api/model
```
