### PR TITLE
fix(pricing): honor free reference image allowance

### DIFF
--- a/apps/new-api/relay/image_handler.go
+++ b/apps/new-api/relay/image_handler.go
@@ -42,7 +42,20 @@ func effectiveFixedImageRequestPriceCNY(modelName string, request *dto.ImageRequ
 		return 0, false
 	}
 	referenceImagePrice := model.EffectiveImageReferencePriceCNY(modelName)
-	return basePrice + referenceImagePrice*float64(len(imageutil.ExtractReferenceImages(request))), true
+	referenceImageCount := len(imageutil.ExtractReferenceImages(request))
+	freeReferenceCount := model.EffectiveImageReferenceFreeCount(modelName)
+	chargeableReferenceCount := chargeableImageReferenceCount(referenceImageCount, freeReferenceCount)
+	if chargeableReferenceCount > 0 {
+		basePrice += referenceImagePrice * float64(chargeableReferenceCount)
+	}
+	return basePrice, true
+}
+
+func chargeableImageReferenceCount(total, free int) int {
+	if total <= free {
+		return 0
+	}
+	return total - free
 }
 
 func (w *captureWriter) Write(b []byte) (int, error) {

--- a/apps/new-api/relay/image_price_test.go
+++ b/apps/new-api/relay/image_price_test.go
@@ -23,3 +23,28 @@ func TestEffectiveFixedImageRequestPriceAddsReferenceImageSurcharge(t *testing.T
 		t.Fatalf("request price = %v, %v; want 1.4, true", price, ok)
 	}
 }
+
+func TestChargeableImageReferenceCountAppliesFreeAllowance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		total int
+		free  int
+		want  int
+	}{
+		{name: "below allowance", total: 2, free: 3, want: 0},
+		{name: "at allowance", total: 3, free: 3, want: 0},
+		{name: "above allowance", total: 5, free: 3, want: 2},
+		{name: "no allowance", total: 2, free: 0, want: 2},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			if got := chargeableImageReferenceCount(test.total, test.free); got != test.want {
+				t.Fatalf("chargeableImageReferenceCount(%d, %d) = %d, want %d", test.total, test.free, got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## 变更描述

图片固定规格计费已经能读取 `reference_image_price_cny`，但此前对所有参考图直接收费，没有使用同一价格配置中的 `reference_image_free_count`。

本 PR 将图片请求价格改为：

```text
base_price + max(reference_image_count - reference_image_free_count, 0) * reference_image_price
```

同时补充低于、等于、高于免费额度以及零免费额度的边界测试。现有未配置免费额度的模型行为保持不变。

不包含任何 Fairy 模型、供应商价格或部署数据。

## 变更类型

- [x] Bug 修复

## 验证

```text
go test -count=1 ./relay
ok github.com/QuantumNous/new-api/relay
```
