### PR TITLE
feat(models): expose complete parameter contracts

### DIFF
--- a/apps/new-api/controller/model_catalog.go
+++ b/apps/new-api/controller/model_catalog.go
@@ -1,7 +1,6 @@
 package controller
 
 import (
-	"encoding/json"
 	"sort"
 	"strings"
 
@@ -94,6 +93,7 @@ func buildCanonicalModelParamsCatalog(models []model.Model) map[string]dto.Model
 			var params []dto.ModelParamSpec
 			if err := common.Unmarshal([]byte(raw.ParamsDef), &params); err == nil {
 				entry.Params = params
+				entry.Sources = mergeModelParamSources(entry.Sources, params)
 			}
 		}
 		if entry.Params == nil {
@@ -155,11 +155,30 @@ func chooseMergedCapabilities(primary string, secondary string) string {
 	if len(merged) == 0 {
 		return ""
 	}
-	data, err := json.Marshal(merged)
+	data, err := common.Marshal(merged)
 	if err != nil {
 		return primary
 	}
 	return string(data)
+}
+
+func mergeModelParamSources(existing []dto.ModelParamSource, params []dto.ModelParamSpec) []dto.ModelParamSource {
+	seen := make(map[string]struct{}, len(existing))
+	result := append([]dto.ModelParamSource(nil), existing...)
+	for _, source := range existing {
+		seen[source.Name+"\x00"+source.URL+"\x00"+source.CheckedAt] = struct{}{}
+	}
+	for _, param := range params {
+		for _, source := range param.Sources {
+			key := source.Name + "\x00" + source.URL + "\x00" + source.CheckedAt
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			result = append(result, source)
+		}
+	}
+	return result
 }
 
 func chooseMergedParamsDef(primary string, secondary string) string {

--- a/apps/new-api/controller/model_catalog_test.go
+++ b/apps/new-api/controller/model_catalog_test.go
@@ -3,7 +3,9 @@ package controller
 import (
 	"testing"
 
+	"github.com/QuantumNous/new-api/dto"
 	"github.com/QuantumNous/new-api/model"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBuildCanonicalModelList(t *testing.T) {
@@ -177,4 +179,32 @@ func TestBuildCanonicalModelParamsCatalogKeepsGeminiImageAspectRatio(t *testing.
 	if entry.Params[1].Key != "image_size" {
 		t.Fatalf("second param key = %q, want image_size", entry.Params[1].Key)
 	}
+}
+
+func TestBuildCanonicalModelParamsCatalogPreservesExtendedConstraints(t *testing.T) {
+	t.Parallel()
+
+	rows := []model.Model{{
+		ModelName:    "constraint-model",
+		Kind:         "video",
+		Capabilities: `["reference_images"]`,
+		ParamsDef:    `[{"key":"images","type":"array","item_type":"object","aliases":["reference_images"],"min_items":1,"max_items":8,"recommended_max_items":4,"required_when":{"all":[{"field":"mode","operator":"eq","value":"reference"}]},"forbidden_when":{"all":[{"field":"mode","operator":"eq","value":"text"}]},"items":{"type":"object","required":["url"]},"item_properties":[{"key":"url","type":"string","required":true}],"constraints":[{"type":"combined_max_items","fields":["images","audios"],"max_items":12}],"limit_status":"documented","sources":[{"name":"provider docs","url":"https://example.com/docs","checked_at":"2026-09-05"}]}]`,
+	}}
+
+	entry := buildCanonicalModelParamsCatalog(rows)["constraint-model"]
+	require.Len(t, entry.Params, 1)
+	param := entry.Params[0]
+	require.Equal(t, "object", param.ItemType)
+	require.Equal(t, []string{"reference_images"}, param.Aliases)
+	require.NotNil(t, param.MinItems)
+	require.Equal(t, 1, *param.MinItems)
+	require.NotNil(t, param.MaxItems)
+	require.Equal(t, 8, *param.MaxItems)
+	require.NotEmpty(t, param.RequiredWhen)
+	require.NotEmpty(t, param.ForbiddenWhen)
+	require.NotEmpty(t, param.Items)
+	require.Len(t, param.ItemProperties, 1)
+	require.Len(t, param.Constraints, 1)
+	require.Equal(t, "documented", param.LimitStatus)
+	require.Equal(t, []dto.ModelParamSource{{Name: "provider docs", URL: "https://example.com/docs", CheckedAt: "2026-09-05"}}, entry.Sources)
 }

--- a/apps/new-api/dto/model_params.go
+++ b/apps/new-api/dto/model_params.go
@@ -2,32 +2,64 @@ package dto
 
 // ModelParamOption is one selectable value for an enum parameter.
 type ModelParamOption struct {
-	Value interface{} `json:"value"`
-	Label string      `json:"label"`
+	Value       interface{} `json:"value"`
+	Label       string      `json:"label"`
+	Description string      `json:"description,omitempty"`
+}
+
+// ModelParamSource records where a parameter contract was verified. It is
+// intentionally part of params_def so both /api/models/list and
+// /api/models/params expose the same provenance without changing the legacy
+// top-level params_def array shape.
+type ModelParamSource struct {
+	Name      string `json:"name,omitempty"`
+	URL       string `json:"url,omitempty"`
+	CheckedAt string `json:"checked_at,omitempty"`
 }
 
 // ModelParamSpec describes a single adjustable parameter for a model.
-// Type is one of: "float", "integer", "boolean", "string", "enum".
+// Type is one of: "float", "integer", "boolean", "string", "enum",
+// "array", or "object".
 // For numeric types, Min/Max/Step apply.
 // For enum type, Options applies.
 // Scope "per_image" marks parameters that apply to individual image_url entries
 // in a chat message, not to the top-level request (e.g. image detail level).
 type ModelParamSpec struct {
-	Key      string             `json:"key"`
-	Type     string             `json:"type"`
-	Label    string             `json:"label,omitempty"`
-	Required bool               `json:"required,omitempty"`
-	Default  interface{}        `json:"default,omitempty"`
-	Min      *float64           `json:"min,omitempty"`
-	Max      *float64           `json:"max,omitempty"`
-	Step     *float64           `json:"step,omitempty"`
-	Options  []ModelParamOption `json:"options,omitempty"`
-	Scope    string             `json:"scope,omitempty"`
+	Key                 string                   `json:"key"`
+	Type                string                   `json:"type"`
+	Label               string                   `json:"label,omitempty"`
+	Description         string                   `json:"description,omitempty"`
+	Required            bool                     `json:"required,omitempty"`
+	UpstreamRequired    bool                     `json:"upstream_required,omitempty"`
+	GatewayDefaulted    bool                     `json:"gateway_defaulted,omitempty"`
+	Default             interface{}              `json:"default,omitempty"`
+	Const               interface{}              `json:"const,omitempty"`
+	Min                 *float64                 `json:"min,omitempty"`
+	Max                 *float64                 `json:"max,omitempty"`
+	Step                *float64                 `json:"step,omitempty"`
+	Options             []ModelParamOption       `json:"options,omitempty"`
+	Scope               string                   `json:"scope,omitempty"`
+	Aliases             []string                 `json:"aliases,omitempty"`
+	Format              string                   `json:"format,omitempty"`
+	Accepts             []string                 `json:"accepts,omitempty"`
+	ItemType            string                   `json:"item_type,omitempty"`
+	Items               map[string]interface{}   `json:"items,omitempty"`
+	ItemProperties      []map[string]interface{} `json:"item_properties,omitempty"`
+	MinItems            *int                     `json:"min_items,omitempty"`
+	MaxItems            *int                     `json:"max_items,omitempty"`
+	RecommendedMaxItems *int                     `json:"recommended_max_items,omitempty"`
+	RequiredWhen        map[string]interface{}   `json:"required_when,omitempty"`
+	ForbiddenWhen       map[string]interface{}   `json:"forbidden_when,omitempty"`
+	AllowedValuesWhen   []map[string]interface{} `json:"allowed_values_when,omitempty"`
+	Constraints         []map[string]interface{} `json:"constraints,omitempty"`
+	LimitStatus         string                   `json:"limit_status,omitempty"`
+	Sources             []ModelParamSource       `json:"sources,omitempty"`
 }
 
 // ModelParamsCatalogEntry is the per-model entry returned by GET /api/models/params.
 type ModelParamsCatalogEntry struct {
-	Kind         string           `json:"kind"`
-	Capabilities []string         `json:"capabilities,omitempty"`
-	Params       []ModelParamSpec `json:"params"`
+	Kind         string             `json:"kind"`
+	Capabilities []string           `json:"capabilities,omitempty"`
+	Params       []ModelParamSpec   `json:"params"`
+	Sources      []ModelParamSource `json:"sources,omitempty"`
 }


### PR DESCRIPTION
## 变更描述

扩展模型参数目录的数据结构，使 `/api/models/params` 能表达媒体模型真实的字段与约束，而不需要为不同供应商创建私有协议。

新增支持：

- 参数与枚举值说明
- `array` / `object` 类型及元素结构
- 字段别名、格式和允许的输入类型
- 数量上下限及建议上限
- 条件必填、条件禁用、条件枚举
- 组合约束和文档缺口状态
- 参数来源、文档地址和核对日期

顶层目录会对所选参数定义中的来源去重汇总。原有字段和 `params_def` 数组形状保持兼容，并补充合成约束回归测试。

该 PR 不包含 Fairy 模型目录、供应商价格、生成脚本、部署文件或私有映射。

## 变更类型

- [x] 新功能

## 验证

```text
go test -count=1 ./dto ./controller
ok github.com/QuantumNous/new-api/dto
ok github.com/QuantumNous/new-api/controller
```
