### PR TITLE
feat(new-api): add Agnes image and video channels

### DIFF
--- a/apps/new-api/constant/api_type.go
+++ b/apps/new-api/constant/api_type.go
@@ -48,5 +48,6 @@ const (
 	APITypeEvolink
 	APITypeKiro
 	APITypeFlow2API
+	APITypeAgnes
 	APITypeDummy // this one is only for count, do not add any channel after this
 )

--- a/apps/new-api/constant/channel.go
+++ b/apps/new-api/constant/channel.go
@@ -78,6 +78,7 @@ const (
 	ChannelTypeGaiscImage     = 73 // G-AISC OpenAI-compatible GPT Image 2 generation/edit channel
 	ChannelTypeAIStudioToAPI  = 74 // Browser-backed Google AI Studio runtime with an importer-managed account pool
 	ChannelTypeLluban         = 75 // Recommended lluban new-api upstream (OpenAI-compatible)
+	ChannelTypeAgnes          = 76 // Agnes AI image generation and asynchronous video tasks
 
 )
 
@@ -158,6 +159,7 @@ var ChannelBaseURLs = []string{
 	"https://sub.g-aisc.com",                        //73 G-AISC Image
 	"",                                              //74 AI Studio To API (operator-supplied runtime URL)
 	"https://tt-api.lluban.com",                     //75 lluban new-api upstream
+	"https://api.agnes-ai.cn",                       //76 Agnes AI
 }
 
 var ChannelTypeNames = map[int]string{
@@ -232,6 +234,7 @@ var ChannelTypeNames = map[int]string{
 	ChannelTypeGaiscImage:     "G-AISC Image",
 	ChannelTypeAIStudioToAPI:  "AI Studio To API",
 	ChannelTypeLluban:         "Lluban API",
+	ChannelTypeAgnes:          "Agnes AI",
 }
 
 func GetChannelTypeName(channelType int) string {

--- a/apps/new-api/constant/protocol.go
+++ b/apps/new-api/constant/protocol.go
@@ -48,6 +48,7 @@ const (
 	ProtocolLingjing      = "lingjing"
 	ProtocolKiro          = "kiro"
 	ProtocolFlow2API      = "flow2api"
+	ProtocolAgnes         = "agnes"
 	ProtocolXinference    = "xinference"
 	ProtocolDeepSeek      = "deepseek"
 	ProtocolZhipuV4       = "zhipu-v4"
@@ -70,6 +71,7 @@ const (
 	ProtocolTaskMegaby    = "task.megaby"
 	ProtocolTaskMagic666  = "task.magic666"
 	ProtocolTaskMediaKit  = "task.volc-mediakit"
+	ProtocolTaskAgnes     = "task.agnes"
 	ProtocolNativeMJ      = "native.midjourney"
 )
 
@@ -165,6 +167,8 @@ var protocolDefinitions = []ProtocolDefinition{
 	relayProtocol(ProtocolOpenAI, "OpenAI Compatible", "OpenAI", "OpenAI Chat Completions, Responses, Images and Embeddings compatible protocol.", APITypeOpenAI, true,
 		[]EndpointType{EndpointTypeOpenAI, EndpointTypeOpenAIResponse, EndpointTypeOpenAIResponseCompact, EndpointTypeImageGeneration, EndpointTypeEmbeddings},
 		ChannelTypeOpenAI, ChannelTypeCustom, ChannelTypeOpenAIMax, ChannelTypeOhMyGPT, ChannelTypeAILS, ChannelTypeAIProxy, ChannelTypeAPI2GPT, ChannelTypeAIGC2D, ChannelType360, ChannelTypeLingYiWanWu, ChannelTypeSiliconFlow, ChannelTypeDeepSeek, ChannelTypeXinference, ChannelTypeXai, ChannelTypeGaiscImage, ChannelTypeAIStudioToAPI, ChannelTypeLluban),
+	relayProtocol(ProtocolAgnes, "Agnes OpenAI Images", "OpenAI", "Agnes image generation exposed through the standard OpenAI Images contract.", APITypeAgnes, false,
+		[]EndpointType{EndpointTypeImageGeneration}, ChannelTypeAgnes),
 	withProtocolOptions(
 		relayProtocol(ProtocolFlow2API, "Flow2API Image Chat", "OpenAI", "Flow2API image generation over OpenAI Chat Completions, including deterministic aspect-ratio and resolution model variants.", APITypeFlow2API, false,
 			[]EndpointType{EndpointTypeOpenAI, EndpointTypeImageGeneration}, ChannelTypeGemini),
@@ -300,6 +304,7 @@ var protocolDefinitions = []ProtocolDefinition{
 	taskProtocol(ProtocolTaskMegaby, "Megaby Task", "Megaby", "Megaby OpenAI-compatible asynchronous video protocol.", TaskPlatformMegaby, ChannelTypeMegaby),
 	taskProtocol(ProtocolTaskMagic666, "Magic666 Task", "Magic666", "Magic666 asynchronous media protocol.", TaskPlatformMagic666, ChannelTypeMagic666),
 	taskProtocol(ProtocolTaskMediaKit, "Volcengine MediaKit Task", "ByteDance", "Volcengine MediaKit enhancement protocol.", TaskPlatformMediaKit, ChannelTypeVolcMediaKit),
+	taskProtocol(ProtocolTaskAgnes, "Agnes OpenAI Video Task", "OpenAI", "Agnes asynchronous video generation exposed through the standard OpenAI Videos contract.", TaskPlatformAgnes, ChannelTypeAgnes),
 	nativeProtocol(ProtocolNativeMJ, "Midjourney Native", "Midjourney", "Midjourney proxy routes handled by the native relay.", ChannelTypeMidjourney, ChannelTypeMidjourneyPlus),
 }
 

--- a/apps/new-api/constant/protocol_test.go
+++ b/apps/new-api/constant/protocol_test.go
@@ -54,6 +54,21 @@ func TestLlubanChannelUsesOpenAICompatibleProtocol(t *testing.T) {
 	}
 }
 
+func TestAgnesProtocolsRegistration(t *testing.T) {
+	if got := ChannelBaseURLs[ChannelTypeAgnes]; got != "https://api.agnes-ai.cn" {
+		t.Fatalf("unexpected Agnes base URL %q", got)
+	}
+
+	imageProtocol, ok := GetProtocolDefinition(ProtocolAgnes)
+	if !ok || imageProtocol.APIType != APITypeAgnes || imageProtocol.Transport != ProtocolTransportRelay {
+		t.Fatalf("unexpected Agnes image protocol: %+v, %v", imageProtocol, ok)
+	}
+	videoProtocol, ok := GetProtocolDefinition(ProtocolTaskAgnes)
+	if !ok || videoProtocol.TaskPlatform != TaskPlatformAgnes || videoProtocol.Transport != ProtocolTransportTask {
+		t.Fatalf("unexpected Agnes video protocol: %+v, %v", videoProtocol, ok)
+	}
+}
+
 func TestProtocolRegistryReturnsDefensiveCopies(t *testing.T) {
 	first, ok := GetProtocolDefinition(ProtocolOpenAI)
 	if !ok {

--- a/apps/new-api/constant/task.go
+++ b/apps/new-api/constant/task.go
@@ -22,6 +22,7 @@ const (
 	TaskPlatformMegaby     TaskPlatform = ProtocolTaskMegaby
 	TaskPlatformMagic666   TaskPlatform = ProtocolTaskMagic666
 	TaskPlatformMediaKit   TaskPlatform = ProtocolTaskMediaKit
+	TaskPlatformAgnes      TaskPlatform = ProtocolTaskAgnes
 )
 
 const (

--- a/apps/new-api/docs/channel/agnes.md
+++ b/apps/new-api/docs/channel/agnes.md
@@ -1,0 +1,31 @@
+# Agnes AI channel
+
+The Agnes channel exposes Agnes image and video models through New API's standard OpenAI-compatible endpoints. The adapter translates client requests to Agnes wire formats and keeps Agnes task identifiers private during polling.
+
+## Models
+
+| Type | Model |
+| --- | --- |
+| Image | `agnes-image-2.5-flash` |
+| Video | `agnes-video-2.5` |
+| Video | `agnes-video-2.5-flash` |
+
+## Images
+
+Use `POST /v1/images/generations`. `size` accepts `1K`, `2K`, `3K`, `4K`, or a pixel size. `ratio` supports `1:1`, `3:4`, `4:3`, `16:9`, `9:16`, `2:3`, `3:2`, and `21:9`.
+
+Reference images may be supplied with the common `images` array. The adapter moves them into Agnes `extra_body.image` and translates `response_format` to the location expected by Agnes.
+
+## Videos
+
+Use `POST /v1/videos` and poll with the returned public task ID at `GET /v1/videos/{task_id}`.
+
+The adapter supports the Agnes `text`, `keyframe`, and `reference` modes:
+
+- `text` accepts prompt-only generation.
+- `keyframe` accepts `first_frame` and `last_frame`; `start_frame` and `end_frame` are aliases.
+- `reference` accepts `images`, `audios`, and structured `videos` entries with `url`, optional `start_seconds`, and optional `require_audio`.
+
+Media references must be public HTTPS URLs accessible by Agnes. Optional `seed`, `n`, `start_seconds`, and `require_audio` values preserve explicit zero or false values.
+
+`agnes-video-2.5` supports 4 to 12 seconds and 720P, 1080P, 1K, or 2K output. `agnes-video-2.5-flash` supports 4 to 12 seconds at 720P. The full model accepts up to 8 images, 3 audio references, and 1 video reference, with at most 12 references total. The flash model accepts up to 5 images and 3 audio references and does not accept video references.

--- a/apps/new-api/relay/channel/agnes/adaptor.go
+++ b/apps/new-api/relay/channel/agnes/adaptor.go
@@ -1,0 +1,347 @@
+package agnes
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/relay/channel/openai"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	ChannelName       = "agnes"
+	ModelImage25Flash = "agnes-image-2.5-flash"
+	imagePath         = "/v1/images/generations"
+)
+
+var (
+	ModelList        = []string{ModelImage25Flash}
+	pixelSizePattern = regexp.MustCompile(`^[1-9][0-9]*x[1-9][0-9]*$`)
+	imageRatios      = map[string]struct{}{
+		"1:1": {}, "3:4": {}, "4:3": {}, "16:9": {}, "9:16": {},
+		"2:3": {}, "3:2": {}, "21:9": {},
+	}
+)
+
+type Adaptor struct {
+	openai.Adaptor
+}
+
+type imagePayload struct {
+	Model        string          `json:"model"`
+	Prompt       string          `json:"prompt"`
+	Size         string          `json:"size"`
+	Ratio        string          `json:"ratio,omitempty"`
+	ReturnBase64 *bool           `json:"return_base64,omitempty"`
+	ExtraBody    *imageExtraBody `json:"extra_body,omitempty"`
+}
+
+type imageExtraBody struct {
+	Image          []string `json:"image,omitempty"`
+	ResponseFormat string   `json:"response_format,omitempty"`
+}
+
+type imageExtraBodyInput struct {
+	Image          json.RawMessage `json:"image,omitempty"`
+	ResponseFormat string          `json:"response_format,omitempty"`
+	ReturnBase64   *bool           `json:"return_base64,omitempty"`
+}
+
+func (a *Adaptor) GetRequestURL(info *relaycommon.RelayInfo) (string, error) {
+	if info.RelayMode == relayconstant.RelayModeImagesGenerations ||
+		info.RelayMode == relayconstant.RelayModeImagesEdits {
+		return strings.TrimRight(info.ChannelBaseUrl, "/") + imagePath, nil
+	}
+	return a.Adaptor.GetRequestURL(info)
+}
+
+func (a *Adaptor) ConvertImageRequest(_ *gin.Context, info *relaycommon.RelayInfo, request dto.ImageRequest) (any, error) {
+	if info.RelayMode != relayconstant.RelayModeImagesGenerations &&
+		info.RelayMode != relayconstant.RelayModeImagesEdits {
+		return nil, errors.New("agnes only supports OpenAI image generation requests")
+	}
+	if request.Mask != nil {
+		return nil, errors.New("agnes-image-2.5-flash does not support mask")
+	}
+	if request.N != nil && *request.N != 1 {
+		return nil, errors.New("agnes-image-2.5-flash n must be 1")
+	}
+	if strings.TrimSpace(request.Prompt) == "" {
+		return nil, errors.New("agnes-image-2.5-flash prompt is required")
+	}
+
+	modelName := strings.TrimSpace(info.UpstreamModelName)
+	if modelName == "" {
+		modelName = strings.TrimSpace(request.Model)
+	}
+	if modelName != ModelImage25Flash {
+		return nil, fmt.Errorf("agnes: unsupported image model %q", modelName)
+	}
+
+	size, ratio, err := resolveImageSizeAndRatio(request)
+	if err != nil {
+		return nil, err
+	}
+	references, err := imageReferences(request)
+	if err != nil {
+		return nil, err
+	}
+	if info.RelayMode == relayconstant.RelayModeImagesEdits && len(references) == 0 {
+		return nil, errors.New("agnes image edits require at least one reference image")
+	}
+
+	extraInput, err := parseImageExtraBody(request.Extra["extra_body"])
+	if err != nil {
+		return nil, err
+	}
+	responseFormat := strings.ToLower(strings.TrimSpace(request.ResponseFormat))
+	if responseFormat == "" {
+		responseFormat = strings.ToLower(strings.TrimSpace(extraInput.ResponseFormat))
+	}
+	if responseFormat == "" {
+		responseFormat = "url"
+	}
+	if responseFormat != "url" && responseFormat != "b64_json" {
+		return nil, errors.New("agnes-image-2.5-flash response_format must be url or b64_json")
+	}
+	explicitReturnBase64, hasExplicitReturnBase64 := rawBoolPointer(request.Extra["return_base64"])
+	if !hasExplicitReturnBase64 && extraInput.ReturnBase64 != nil {
+		explicitReturnBase64 = extraInput.ReturnBase64
+		hasExplicitReturnBase64 = true
+	}
+	if hasExplicitReturnBase64 {
+		if *explicitReturnBase64 {
+			responseFormat = "b64_json"
+		}
+	}
+
+	payload := imagePayload{
+		Model:  modelName,
+		Prompt: strings.TrimSpace(request.Prompt),
+		Size:   size,
+		Ratio:  ratio,
+	}
+	extraBody := &imageExtraBody{Image: references}
+	if responseFormat == "b64_json" && len(references) == 0 {
+		value := true
+		payload.ReturnBase64 = &value
+	} else {
+		extraBody.ResponseFormat = responseFormat
+		if hasExplicitReturnBase64 && responseFormat == "url" {
+			payload.ReturnBase64 = explicitReturnBase64
+		}
+	}
+	if len(extraBody.Image) > 0 || extraBody.ResponseFormat != "" {
+		payload.ExtraBody = extraBody
+	}
+	return payload, nil
+}
+
+func (a *Adaptor) GetModelList() []string { return ModelList }
+
+func (a *Adaptor) GetChannelName() string { return ChannelName }
+
+func resolveImageSizeAndRatio(request dto.ImageRequest) (string, string, error) {
+	tier := ""
+	for _, key := range []string{"resolution", "image_size", "imageSize"} {
+		if value, ok := rawString(request.Extra[key]); ok && value != "" {
+			tier = strings.ToUpper(value)
+			break
+		}
+	}
+	size := strings.TrimSpace(request.Size)
+	if isImageTier(size) {
+		tier = strings.ToUpper(size)
+		size = ""
+	}
+	if tier != "" && !isImageTier(tier) {
+		return "", "", fmt.Errorf("agnes-image-2.5-flash size must be 1K, 2K, 3K, or 4K, got %q", tier)
+	}
+
+	ratio := ""
+	for _, key := range []string{"ratio", "aspect_ratio", "aspectRatio"} {
+		if value, ok := rawString(request.Extra[key]); ok && value != "" {
+			ratio = value
+			break
+		}
+	}
+	if strings.Contains(size, ":") {
+		if ratio == "" {
+			ratio = size
+		}
+		size = ""
+	}
+	if ratio != "" {
+		if _, ok := imageRatios[ratio]; !ok {
+			return "", "", fmt.Errorf("agnes-image-2.5-flash unsupported ratio %q", ratio)
+		}
+	}
+
+	if tier != "" {
+		size = tier
+	} else if size == "" || strings.EqualFold(size, "auto") {
+		size = "1K"
+	} else if !pixelSizePattern.MatchString(strings.ToLower(size)) {
+		return "", "", fmt.Errorf("agnes-image-2.5-flash size must be a resolution tier or WIDTHxHEIGHT, got %q", size)
+	}
+
+	if isImageTier(size) && ratio == "" {
+		ratio = "1:1"
+	}
+	return size, ratio, nil
+}
+
+func isImageTier(value string) bool {
+	switch strings.ToUpper(strings.TrimSpace(value)) {
+	case "1K", "2K", "3K", "4K":
+		return true
+	default:
+		return false
+	}
+}
+
+func imageReferences(request dto.ImageRequest) ([]string, error) {
+	values := make([]string, 0, 1+len(request.Images))
+	appendValue := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		for _, existing := range values {
+			if existing == value {
+				return
+			}
+		}
+		values = append(values, value)
+	}
+	if len(request.Image) > 0 && string(request.Image) != "null" {
+		var single string
+		if common.Unmarshal(request.Image, &single) == nil {
+			appendValue(single)
+		} else {
+			var many []string
+			if common.Unmarshal(request.Image, &many) == nil {
+				for _, value := range many {
+					appendValue(value)
+				}
+			} else {
+				var references []dto.ImageURLReference
+				if err := common.Unmarshal(request.Image, &references); err != nil {
+					return nil, errors.New("image must be a URL, URL array, or image_url object array")
+				}
+				for _, reference := range references {
+					imageURL, err := agnesImageReferenceURL(reference)
+					if err != nil {
+						return nil, err
+					}
+					appendValue(imageURL)
+				}
+			}
+		}
+	}
+	for _, reference := range request.Images {
+		imageURL, err := agnesImageReferenceURL(reference)
+		if err != nil {
+			return nil, err
+		}
+		appendValue(imageURL)
+	}
+	extraInput, err := parseImageExtraBody(request.Extra["extra_body"])
+	if err != nil {
+		return nil, err
+	}
+	if len(extraInput.Image) > 0 && string(extraInput.Image) != "null" {
+		if err := appendImageReferenceRaw(extraInput.Image, appendValue); err != nil {
+			return nil, fmt.Errorf("extra_body.image: %w", err)
+		}
+	}
+	for _, key := range []string{"image_urls", "urls"} {
+		raw := request.Extra[key]
+		if len(raw) == 0 {
+			continue
+		}
+		var many []string
+		if err := common.Unmarshal(raw, &many); err != nil {
+			return nil, fmt.Errorf("%s must be an array of URLs", key)
+		}
+		for _, value := range many {
+			appendValue(value)
+		}
+	}
+	return values, nil
+}
+
+func appendImageReferenceRaw(raw json.RawMessage, appendValue func(string)) error {
+	var single string
+	if common.Unmarshal(raw, &single) == nil {
+		appendValue(single)
+		return nil
+	}
+	var many []string
+	if common.Unmarshal(raw, &many) == nil {
+		for _, value := range many {
+			appendValue(value)
+		}
+		return nil
+	}
+	var references []dto.ImageURLReference
+	if err := common.Unmarshal(raw, &references); err != nil {
+		return errors.New("must be a URL, URL array, or image_url object array")
+	}
+	for _, reference := range references {
+		imageURL, err := agnesImageReferenceURL(reference)
+		if err != nil {
+			return err
+		}
+		appendValue(imageURL)
+	}
+	return nil
+}
+
+func agnesImageReferenceURL(reference dto.ImageURLReference) (string, error) {
+	imageURL := strings.TrimSpace(reference.ImageURL)
+	if imageURL == "" {
+		return "", errors.New("agnes image_url must not be empty")
+	}
+	return imageURL, nil
+}
+
+func parseImageExtraBody(raw json.RawMessage) (imageExtraBodyInput, error) {
+	if len(raw) == 0 || string(raw) == "null" {
+		return imageExtraBodyInput{}, nil
+	}
+	var input imageExtraBodyInput
+	if err := common.Unmarshal(raw, &input); err != nil {
+		return imageExtraBodyInput{}, errors.New("extra_body must be an object")
+	}
+	return input, nil
+}
+
+func rawString(raw json.RawMessage) (string, bool) {
+	if len(raw) == 0 {
+		return "", false
+	}
+	var value string
+	if common.Unmarshal(raw, &value) != nil {
+		return "", false
+	}
+	return strings.TrimSpace(value), true
+}
+
+func rawBoolPointer(raw json.RawMessage) (*bool, bool) {
+	if len(raw) == 0 {
+		return nil, false
+	}
+	var value bool
+	if common.Unmarshal(raw, &value) != nil {
+		return nil, false
+	}
+	return &value, true
+}

--- a/apps/new-api/relay/channel/agnes/adaptor_test.go
+++ b/apps/new-api/relay/channel/agnes/adaptor_test.go
@@ -1,0 +1,164 @@
+package agnes
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	relayconstant "github.com/QuantumNous/new-api/relay/constant"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func imageContext() *gin.Context {
+	gin.SetMode(gin.TestMode)
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	context.Request = httptest.NewRequest(http.MethodPost, "/v1/images/generations", nil)
+	context.Request.Header.Set("Content-Type", "application/json")
+	return context
+}
+
+func imageInfo(mode int) *relaycommon.RelayInfo {
+	return &relaycommon.RelayInfo{
+		RelayMode: mode,
+		ChannelMeta: &relaycommon.ChannelMeta{
+			ChannelBaseUrl:    "https://api.agnes-ai.cn",
+			UpstreamModelName: ModelImage25Flash,
+		},
+	}
+}
+
+func TestConvertImageRequestMovesReferencesAndResponseFormatIntoExtraBody(t *testing.T) {
+	t.Parallel()
+	request := dto.ImageRequest{
+		Model:          ModelImage25Flash,
+		Prompt:         "combine the references",
+		Size:           "16:9",
+		ResponseFormat: "url",
+		Images: []dto.ImageURLReference{
+			{ImageURL: "https://example.com/a.png"},
+			{ImageURL: "https://example.com/b.png"},
+		},
+		Extra: map[string]json.RawMessage{
+			"resolution": json.RawMessage(`"3K"`),
+		},
+	}
+
+	converted, err := (&Adaptor{}).ConvertImageRequest(
+		imageContext(),
+		imageInfo(relayconstant.RelayModeImagesGenerations),
+		request,
+	)
+	require.NoError(t, err)
+	payload := converted.(imagePayload)
+	require.Equal(t, "3K", payload.Size)
+	require.Equal(t, "16:9", payload.Ratio)
+	require.NotNil(t, payload.ExtraBody)
+	require.Equal(t, []string{"https://example.com/a.png", "https://example.com/b.png"}, payload.ExtraBody.Image)
+	require.Equal(t, "url", payload.ExtraBody.ResponseFormat)
+	require.Nil(t, payload.ReturnBase64)
+
+	encoded, err := common.Marshal(payload)
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, common.Unmarshal(encoded, &raw))
+	require.NotContains(t, raw, "response_format")
+	require.NotContains(t, raw, "image")
+}
+
+func TestConvertImageRequestUsesReturnBase64ForTextToImage(t *testing.T) {
+	t.Parallel()
+	request := dto.ImageRequest{
+		Model:          ModelImage25Flash,
+		Prompt:         "a luminous city",
+		Size:           "2K",
+		ResponseFormat: "b64_json",
+	}
+	converted, err := (&Adaptor{}).ConvertImageRequest(
+		imageContext(),
+		imageInfo(relayconstant.RelayModeImagesGenerations),
+		request,
+	)
+	require.NoError(t, err)
+	payload := converted.(imagePayload)
+	require.NotNil(t, payload.ReturnBase64)
+	require.True(t, *payload.ReturnBase64)
+	require.Nil(t, payload.ExtraBody)
+}
+
+func TestConvertImageRequestAcceptsOpenAIExtraBodyInput(t *testing.T) {
+	t.Parallel()
+	request := dto.ImageRequest{
+		Model:  ModelImage25Flash,
+		Prompt: "edit from SDK extra body",
+		Size:   "1K",
+		Extra: map[string]json.RawMessage{
+			"extra_body": json.RawMessage(`{
+				"image":["https://example.com/reference.png"],
+				"response_format":"b64_json"
+			}`),
+		},
+	}
+	converted, err := (&Adaptor{}).ConvertImageRequest(
+		imageContext(),
+		imageInfo(relayconstant.RelayModeImagesGenerations),
+		request,
+	)
+	require.NoError(t, err)
+	payload := converted.(imagePayload)
+	require.NotNil(t, payload.ExtraBody)
+	require.Equal(t, []string{"https://example.com/reference.png"}, payload.ExtraBody.Image)
+	require.Equal(t, "b64_json", payload.ExtraBody.ResponseFormat)
+}
+
+func TestConvertImageRequestPreservesExplicitFalseReturnBase64(t *testing.T) {
+	t.Parallel()
+	request := dto.ImageRequest{
+		Model:  ModelImage25Flash,
+		Prompt: "a product photo",
+		Extra: map[string]json.RawMessage{
+			"return_base64": json.RawMessage(`false`),
+		},
+	}
+	converted, err := (&Adaptor{}).ConvertImageRequest(
+		imageContext(),
+		imageInfo(relayconstant.RelayModeImagesGenerations),
+		request,
+	)
+	require.NoError(t, err)
+	encoded, err := common.Marshal(converted)
+	require.NoError(t, err)
+	var raw map[string]json.RawMessage
+	require.NoError(t, common.Unmarshal(encoded, &raw))
+	require.JSONEq(t, `false`, string(raw["return_base64"]))
+}
+
+func TestAgnesImageEditsUseGenerationEndpoint(t *testing.T) {
+	t.Parallel()
+	adaptor := &Adaptor{}
+	info := imageInfo(relayconstant.RelayModeImagesEdits)
+	requestURL, err := adaptor.GetRequestURL(info)
+	require.NoError(t, err)
+	require.Equal(t, "https://api.agnes-ai.cn/v1/images/generations", requestURL)
+
+	_, err = adaptor.ConvertImageRequest(imageContext(), info, dto.ImageRequest{
+		Model:  ModelImage25Flash,
+		Prompt: "edit",
+	})
+	require.ErrorContains(t, err, "require at least one reference image")
+}
+
+func TestAgnesImageRejectsUnsupportedN(t *testing.T) {
+	t.Parallel()
+	n := uint(2)
+	_, err := (&Adaptor{}).ConvertImageRequest(
+		imageContext(),
+		imageInfo(relayconstant.RelayModeImagesGenerations),
+		dto.ImageRequest{Model: ModelImage25Flash, Prompt: "two images", N: &n},
+	)
+	require.ErrorContains(t, err, "n must be 1")
+}

--- a/apps/new-api/relay/channel/task/agnes/adaptor.go
+++ b/apps/new-api/relay/channel/task/agnes/adaptor.go
@@ -1,0 +1,709 @@
+package agnes
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/constant"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/model"
+	"github.com/QuantumNous/new-api/relay/channel"
+	taskcommon "github.com/QuantumNous/new-api/relay/channel/task/taskcommon"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/gin-gonic/gin"
+)
+
+const (
+	ChannelName       = "agnes"
+	ModelVideo25      = "agnes-video-2.5"
+	ModelVideo25Flash = "agnes-video-2.5-flash"
+
+	submitPath = "/v1/videos"
+	fetchPath  = "/agnesapi"
+)
+
+var (
+	ModelList   = []string{ModelVideo25, ModelVideo25Flash}
+	validRatios = map[string]struct{}{
+		"21:9": {}, "16:9": {}, "4:3": {}, "1:1": {}, "3:4": {}, "9:16": {},
+	}
+)
+
+type TaskAdaptor struct {
+	taskcommon.BaseBilling
+	apiKey  string
+	baseURL string
+}
+
+type submitPayload struct {
+	Model       string                           `json:"model"`
+	Prompt      string                           `json:"prompt"`
+	Mode        string                           `json:"mode"`
+	Seconds     string                           `json:"seconds"`
+	Size        string                           `json:"size"`
+	AspectRatio string                           `json:"aspect_ratio"`
+	Seed        *int                             `json:"seed,omitempty"`
+	N           *int                             `json:"n,omitempty"`
+	FirstFrame  string                           `json:"first_frame,omitempty"`
+	LastFrame   string                           `json:"last_frame,omitempty"`
+	Images      []string                         `json:"images,omitempty"`
+	Audios      []string                         `json:"audios,omitempty"`
+	Videos      []relaycommon.TaskVideoReference `json:"videos,omitempty"`
+}
+
+type videoResponse struct {
+	ID          string          `json:"id,omitempty"`
+	TaskID      string          `json:"task_id,omitempty"`
+	VideoID     string          `json:"video_id,omitempty"`
+	URL         string          `json:"url,omitempty"`
+	Object      string          `json:"object,omitempty"`
+	Model       string          `json:"model,omitempty"`
+	Status      string          `json:"status,omitempty"`
+	Progress    int             `json:"progress,omitempty"`
+	CreatedAt   int64           `json:"created_at,omitempty"`
+	CompletedAt int64           `json:"completed_at,omitempty"`
+	Seconds     string          `json:"seconds,omitempty"`
+	Size        string          `json:"size,omitempty"`
+	Metadata    *responseMeta   `json:"metadata,omitempty"`
+	Error       *responseError  `json:"error,omitempty"`
+	Message     string          `json:"message,omitempty"`
+	Detail      json.RawMessage `json:"detail,omitempty"`
+}
+
+type responseMeta struct {
+	URL string `json:"url,omitempty"`
+}
+
+type responseError struct {
+	Code    string `json:"code,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type pollIdentity struct {
+	VideoID string `json:"video_id"`
+	Model   string `json:"model"`
+}
+
+type normalizedRequest struct {
+	request     relaycommon.TaskSubmitReq
+	model       string
+	mode        string
+	resolution  string
+	aspectRatio string
+}
+
+func (a *TaskAdaptor) Init(info *relaycommon.RelayInfo) {
+	a.baseURL = agnesRoot(info.ChannelBaseUrl)
+	a.apiKey = info.ApiKey
+}
+
+func (a *TaskAdaptor) ValidateRequestAndSetAction(c *gin.Context, info *relaycommon.RelayInfo) *dto.TaskError {
+	if taskErr := relaycommon.ValidateBasicTaskRequest(c, info, constant.TaskActionGenerate); taskErr != nil {
+		return taskErr
+	}
+	req, err := relaycommon.GetTaskRequest(c)
+	if err != nil {
+		return service.TaskErrorWrapperLocal(err, "invalid_request", http.StatusBadRequest)
+	}
+	normalized, err := normalizeRequest(req)
+	if err != nil {
+		return service.TaskErrorWrapperLocal(err, "invalid_request", http.StatusBadRequest)
+	}
+	relaycommon.SetTaskRequest(c, normalized.request)
+	return nil
+}
+
+func (a *TaskAdaptor) BuildRequestURL(_ *relaycommon.RelayInfo) (string, error) {
+	return a.baseURL + submitPath, nil
+}
+
+func (a *TaskAdaptor) BuildRequestHeader(_ *gin.Context, req *http.Request, _ *relaycommon.RelayInfo) error {
+	req.Header.Set("Authorization", "Bearer "+a.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	return nil
+}
+
+func (a *TaskAdaptor) BuildRequestBody(c *gin.Context, info *relaycommon.RelayInfo) (io.Reader, error) {
+	req, err := relaycommon.GetTaskRequest(c)
+	if err != nil {
+		return nil, err
+	}
+	normalized, err := normalizeRequest(req)
+	if err != nil {
+		return nil, err
+	}
+	modelName := strings.TrimSpace(info.UpstreamModelName)
+	if modelName == "" {
+		modelName = normalized.model
+	}
+	payload := submitPayload{
+		Model:       modelName,
+		Prompt:      strings.TrimSpace(normalized.request.Prompt),
+		Mode:        normalized.mode,
+		Seconds:     strconv.Itoa(normalized.request.Duration),
+		Size:        strings.ToUpper(normalized.resolution),
+		AspectRatio: normalized.aspectRatio,
+		Seed:        normalized.request.Seed,
+		N:           normalized.request.N,
+		FirstFrame:  strings.TrimSpace(normalized.request.StartFrame),
+		LastFrame:   strings.TrimSpace(normalized.request.EndFrame),
+		Images:      normalized.request.Images,
+		Audios:      normalized.request.ReferenceAudios,
+		Videos:      normalized.request.VideoReferences,
+	}
+	data, err := common.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(data), nil
+}
+
+func (a *TaskAdaptor) DoRequest(c *gin.Context, info *relaycommon.RelayInfo, requestBody io.Reader) (*http.Response, error) {
+	return channel.DoTaskApiRequest(a, c, info, requestBody)
+}
+
+func (a *TaskAdaptor) DoResponse(c *gin.Context, resp *http.Response, info *relaycommon.RelayInfo) (string, []byte, *dto.TaskError) {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", nil, service.TaskErrorWrapper(err, "read_response_body_failed", http.StatusInternalServerError)
+	}
+	_ = resp.Body.Close()
+	var response videoResponse
+	if err := common.Unmarshal(body, &response); err != nil {
+		return "", nil, service.TaskErrorWrapper(fmt.Errorf("unmarshal Agnes response: %w", err), "unmarshal_response_body_failed", http.StatusInternalServerError)
+	}
+	if strings.TrimSpace(response.VideoID) == "" {
+		message := response.errorMessage()
+		if message == "" {
+			message = "Agnes video submission returned no video_id"
+		}
+		return "", body, service.TaskErrorWrapper(errors.New(message), "agnes_submit_failed", http.StatusBadGateway)
+	}
+
+	result := response.toOpenAIVideo(info.PublicTaskID, info.OriginModelName)
+	c.JSON(http.StatusOK, result)
+	pollModel := strings.TrimSpace(response.Model)
+	if pollModel == "" {
+		pollModel = strings.TrimSpace(info.UpstreamModelName)
+	}
+	if pollModel == "" {
+		pollModel = strings.TrimSpace(info.OriginModelName)
+	}
+	encodedID, err := encodePollIdentity(response.VideoID, pollModel)
+	if err != nil {
+		return "", body, service.TaskErrorWrapper(err, "agnes_task_id_encode_failed", http.StatusInternalServerError)
+	}
+	return encodedID, body, nil
+}
+
+func (a *TaskAdaptor) FetchTask(baseURL, key string, body map[string]any, proxy string) (*http.Response, error) {
+	encodedID, ok := body["task_id"].(string)
+	if !ok || strings.TrimSpace(encodedID) == "" {
+		return nil, errors.New("invalid task_id")
+	}
+	identity, err := decodePollIdentity(encodedID)
+	if err != nil {
+		return nil, err
+	}
+	query := url.Values{}
+	query.Set("video_id", identity.VideoID)
+	query.Set("model_name", identity.Model)
+	requestURL := agnesRoot(baseURL) + fetchPath + "?" + query.Encode()
+	req, err := http.NewRequest(http.MethodGet, requestURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", "Bearer "+key)
+	req.Header.Set("Accept", "application/json")
+	client, err := service.GetHttpClientWithProxy(proxy)
+	if err != nil {
+		return nil, fmt.Errorf("new proxy http client failed: %w", err)
+	}
+	if client == nil {
+		client = http.DefaultClient
+	}
+	return client.Do(req)
+}
+
+func (a *TaskAdaptor) ParseTaskResult(body []byte) (*relaycommon.TaskInfo, error) {
+	var response videoResponse
+	if err := common.Unmarshal(body, &response); err != nil {
+		return nil, fmt.Errorf("unmarshal Agnes task result failed: %w", err)
+	}
+	result := &relaycommon.TaskInfo{Progress: progressString(response.Progress)}
+	switch strings.ToLower(strings.TrimSpace(response.Status)) {
+	case "queued":
+		result.Status = model.TaskStatusQueued
+	case "in_progress", "processing", "running":
+		result.Status = model.TaskStatusInProgress
+	case "completed", "succeeded", "success":
+		result.Status = model.TaskStatusSuccess
+		result.Progress = taskcommon.ProgressComplete
+		result.Url = response.resultURL()
+		if result.Url == "" {
+			return nil, fmt.Errorf("Agnes video %q completed without a result URL", response.VideoID)
+		}
+	case "failed", "cancelled", "canceled":
+		result.Status = model.TaskStatusFailure
+		result.Progress = taskcommon.ProgressComplete
+		result.Reason = response.errorMessage()
+		if result.Reason == "" {
+			result.Reason = response.Status
+		}
+	default:
+		if message := response.errorMessage(); message != "" {
+			result.Status = model.TaskStatusFailure
+			result.Progress = taskcommon.ProgressComplete
+			result.Reason = message
+		} else {
+			return nil, fmt.Errorf("Agnes video %q returned unknown status %q", response.VideoID, response.Status)
+		}
+	}
+	return result, nil
+}
+
+func (a *TaskAdaptor) ConvertToOpenAIVideo(task *model.Task) ([]byte, error) {
+	result := dto.NewOpenAIVideo()
+	result.ID = task.TaskID
+	result.TaskID = task.TaskID
+	result.Model = task.Properties.OriginModelName
+	result.Status = task.Status.ToVideoStatus()
+	result.SetProgressStr(task.Progress)
+	result.CreatedAt = task.CreatedAt
+	result.CompletedAt = task.UpdatedAt
+	if url := strings.TrimSpace(task.GetResultURL()); url != "" {
+		result.SetMetadata("url", url)
+	}
+	if len(task.Data) > 0 {
+		var response videoResponse
+		if common.Unmarshal(task.Data, &response) == nil {
+			if response.Seconds != "" {
+				result.Seconds = response.Seconds
+			}
+			if response.Size != "" {
+				result.Size = response.Size
+			}
+			if url := response.resultURL(); url != "" {
+				result.SetMetadata("url", url)
+			}
+			if message := response.errorMessage(); message != "" && task.Status == model.TaskStatusFailure {
+				code := ""
+				if response.Error != nil {
+					code = strings.TrimSpace(response.Error.Code)
+				}
+				result.Error = &dto.OpenAIVideoError{Message: message, Code: code}
+			}
+		}
+	}
+	return common.Marshal(result)
+}
+
+func (a *TaskAdaptor) GetModelList() []string { return ModelList }
+
+func (a *TaskAdaptor) GetChannelName() string { return ChannelName }
+
+func normalizeRequest(req relaycommon.TaskSubmitReq) (normalizedRequest, error) {
+	modelName := strings.TrimSpace(req.Model)
+	if modelName != ModelVideo25 && modelName != ModelVideo25Flash {
+		return normalizedRequest{}, fmt.Errorf("agnes: unsupported video model %q", modelName)
+	}
+	if strings.TrimSpace(req.Prompt) == "" {
+		return normalizedRequest{}, fmt.Errorf("agnes %s: prompt is required", modelName)
+	}
+	duration := req.Duration
+	if duration <= 0 && strings.TrimSpace(req.Seconds) != "" {
+		parsed, err := strconv.Atoi(strings.TrimSpace(req.Seconds))
+		if err != nil {
+			return normalizedRequest{}, fmt.Errorf("agnes %s: seconds must be an integer string", modelName)
+		}
+		duration = parsed
+	}
+	if duration <= 0 {
+		duration = 5
+	}
+	if duration < 4 || duration > 12 {
+		return normalizedRequest{}, fmt.Errorf("agnes %s: seconds must be between 4 and 12", modelName)
+	}
+	if req.N != nil && *req.N != 1 {
+		return normalizedRequest{}, fmt.Errorf("agnes %s: n must be 1", modelName)
+	}
+
+	resolution, aspectRatio, err := resolveVideoSpec(req)
+	if err != nil {
+		return normalizedRequest{}, fmt.Errorf("agnes %s: %w", modelName, err)
+	}
+	if modelName == ModelVideo25Flash && resolution != "720p" {
+		return normalizedRequest{}, fmt.Errorf("agnes-video-2.5-flash size must be 720P")
+	}
+	if resolution == "1k" {
+		aspectRatio = "1:1"
+	}
+
+	images := uniqueStrings(req.Images)
+	audios := uniqueStrings(append(append([]string{}, req.ReferenceAudios...), req.Audios...))
+	videos := append([]relaycommon.TaskVideoReference(nil), req.VideoReferences...)
+	for _, value := range uniqueStrings(req.ReferenceVideos) {
+		videos = append(videos, relaycommon.TaskVideoReference{URL: value})
+	}
+	if err := validateAgnesMediaURL("first_frame", req.StartFrame); err != nil {
+		return normalizedRequest{}, err
+	}
+	if err := validateAgnesMediaURL("last_frame", req.EndFrame); err != nil {
+		return normalizedRequest{}, err
+	}
+	for index, value := range images {
+		if err := validateAgnesMediaURL(fmt.Sprintf("images[%d]", index), value); err != nil {
+			return normalizedRequest{}, err
+		}
+	}
+	for index, value := range audios {
+		if err := validateAgnesMediaURL(fmt.Sprintf("audios[%d]", index), value); err != nil {
+			return normalizedRequest{}, err
+		}
+	}
+	for index := range videos {
+		videos[index].URL = strings.TrimSpace(videos[index].URL)
+		if videos[index].URL == "" {
+			return normalizedRequest{}, fmt.Errorf("videos[%d].url is required", index)
+		}
+		if err := validateAgnesMediaURL(fmt.Sprintf("videos[%d].url", index), videos[index].URL); err != nil {
+			return normalizedRequest{}, err
+		}
+		if videos[index].StartSeconds != nil && *videos[index].StartSeconds < 0 {
+			return normalizedRequest{}, fmt.Errorf("videos[%d].start_seconds must be non-negative", index)
+		}
+	}
+
+	mode := strings.ToLower(strings.TrimSpace(req.Mode))
+	if mode == "" {
+		switch {
+		case strings.TrimSpace(req.StartFrame) != "" || strings.TrimSpace(req.EndFrame) != "":
+			mode = "keyframe"
+		case len(images)+len(audios)+len(videos) > 0:
+			mode = "reference"
+		default:
+			mode = "text"
+		}
+	}
+	if mode != "text" && mode != "keyframe" && mode != "reference" {
+		return normalizedRequest{}, fmt.Errorf("mode must be text, keyframe, or reference")
+	}
+	hasFrames := strings.TrimSpace(req.StartFrame) != "" || strings.TrimSpace(req.EndFrame) != ""
+	hasReferences := len(images)+len(audios)+len(videos) > 0
+	switch mode {
+	case "text":
+		if hasFrames || hasReferences {
+			return normalizedRequest{}, fmt.Errorf("text mode does not accept reference media")
+		}
+	case "keyframe":
+		if !hasFrames {
+			return normalizedRequest{}, fmt.Errorf("keyframe mode requires first_frame or last_frame")
+		}
+		if hasReferences {
+			return normalizedRequest{}, fmt.Errorf("keyframe mode does not accept images, audios, or videos")
+		}
+	case "reference":
+		if hasFrames {
+			return normalizedRequest{}, fmt.Errorf("reference mode does not accept first_frame or last_frame")
+		}
+		if !hasReferences {
+			return normalizedRequest{}, fmt.Errorf("reference mode requires images, audios, or videos")
+		}
+	}
+
+	if modelName == ModelVideo25Flash {
+		if len(images) > 5 {
+			return normalizedRequest{}, fmt.Errorf("images length must not exceed 5")
+		}
+		if len(audios) > 3 {
+			return normalizedRequest{}, fmt.Errorf("audios length must not exceed 3")
+		}
+		if len(videos) > 0 {
+			return normalizedRequest{}, fmt.Errorf("videos is not supported by agnes-video-2.5-flash")
+		}
+	} else {
+		if len(images) > 8 {
+			return normalizedRequest{}, fmt.Errorf("images length must not exceed 8")
+		}
+		if len(audios) > 3 {
+			return normalizedRequest{}, fmt.Errorf("audios length must not exceed 3")
+		}
+		if len(videos) > 1 {
+			return normalizedRequest{}, fmt.Errorf("videos length must not exceed 1")
+		}
+		if len(images)+len(audios)+len(videos) > 12 {
+			return normalizedRequest{}, fmt.Errorf("reference media count must not exceed 12")
+		}
+	}
+
+	req.Model = modelName
+	req.Mode = mode
+	req.Duration = duration
+	req.Seconds = strconv.Itoa(duration)
+	req.Resolution = resolution
+	req.Size = strings.ToUpper(resolution)
+	req.AspectRatio = aspectRatio
+	req.Images = images
+	req.ReferenceAudios = audios
+	req.VideoReferences = videos
+	return normalizedRequest{
+		request:     req,
+		model:       modelName,
+		mode:        mode,
+		resolution:  resolution,
+		aspectRatio: aspectRatio,
+	}, nil
+}
+
+func validateAgnesMediaURL(field, value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	parsed, err := url.Parse(value)
+	if err != nil || !strings.EqualFold(parsed.Scheme, "https") || strings.TrimSpace(parsed.Host) == "" {
+		return fmt.Errorf("%s must be a public HTTPS URL accessible by Agnes", field)
+	}
+	return nil
+}
+
+func resolveVideoSpec(req relaycommon.TaskSubmitReq) (string, string, error) {
+	rawResolution := strings.TrimSpace(req.Resolution)
+	if rawResolution == "" && req.Metadata != nil {
+		if value, ok := req.Metadata["resolution"].(string); ok {
+			rawResolution = strings.TrimSpace(value)
+		}
+	}
+	resolution := normalizeResolution(rawResolution)
+	if rawResolution != "" && resolution == "" {
+		return "", "", fmt.Errorf("size must be 720P, 1080P, 1K, or 2K")
+	}
+	ratio := strings.TrimSpace(req.AspectRatio)
+	if ratio == "" && req.Metadata != nil {
+		if value, ok := req.Metadata["aspect_ratio"].(string); ok {
+			ratio = strings.TrimSpace(value)
+		}
+	}
+	size := strings.TrimSpace(req.Size)
+	if resolution == "" && normalizeResolution(size) != "" {
+		resolution = normalizeResolution(size)
+	}
+	if mappedResolution, mappedRatio, ok := videoPixelSpec(size); ok {
+		if resolution == "" {
+			resolution = mappedResolution
+		}
+		if ratio == "" {
+			ratio = mappedRatio
+		}
+	} else if ratio == "" && strings.Contains(size, ":") {
+		ratio = size
+	} else if resolution == "" && size != "" && !strings.EqualFold(size, "auto") {
+		return "", "", fmt.Errorf("size must be 720P, 1080P, 1K, or 2K")
+	}
+	if resolution == "" {
+		resolution = "720p"
+	}
+	if resolution != "720p" && resolution != "1080p" && resolution != "1k" && resolution != "2k" {
+		return "", "", fmt.Errorf("size must be 720P, 1080P, 1K, or 2K")
+	}
+	if ratio == "" {
+		ratio = "16:9"
+	}
+	if _, ok := validRatios[ratio]; !ok {
+		return "", "", fmt.Errorf("unsupported aspect_ratio %q", ratio)
+	}
+	return resolution, ratio, nil
+}
+
+func normalizeResolution(value string) string {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "720", "720p":
+		return "720p"
+	case "1080", "1080p":
+		return "1080p"
+	case "1k":
+		return "1k"
+	case "2k", "1440p":
+		return "2k"
+	default:
+		return ""
+	}
+}
+
+func videoPixelSpec(value string) (string, string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1470x630", "1680x720":
+		return "720p", "21:9", true
+	case "1280x720", "1280x704":
+		return "720p", "16:9", true
+	case "1112x834", "960x720":
+		return "720p", "4:3", true
+	case "960x960", "720x720":
+		return "720p", "1:1", true
+	case "834x1112", "720x960":
+		return "720p", "3:4", true
+	case "720x1280":
+		return "720p", "9:16", true
+	case "2206x946":
+		return "1080p", "21:9", true
+	case "1920x1080":
+		return "1080p", "16:9", true
+	case "1664x1248":
+		return "1080p", "4:3", true
+	case "1440x1440":
+		return "1080p", "1:1", true
+	case "1248x1664":
+		return "1080p", "3:4", true
+	case "1080x1920":
+		return "1080p", "9:16", true
+	case "1024x1024":
+		return "1k", "1:1", true
+	case "2940x1260":
+		return "2k", "21:9", true
+	case "2560x1440":
+		return "2k", "16:9", true
+	case "2224x1668":
+		return "2k", "4:3", true
+	case "1920x1920":
+		return "2k", "1:1", true
+	case "1668x2224":
+		return "2k", "3:4", true
+	case "1440x2560":
+		return "2k", "9:16", true
+	default:
+		return "", "", false
+	}
+}
+
+func uniqueStrings(values []string) []string {
+	result := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
+}
+
+func encodePollIdentity(videoID, modelName string) (string, error) {
+	identity := pollIdentity{VideoID: strings.TrimSpace(videoID), Model: strings.TrimSpace(modelName)}
+	if identity.VideoID == "" || (identity.Model != ModelVideo25 && identity.Model != ModelVideo25Flash) {
+		return "", errors.New("invalid Agnes poll identity")
+	}
+	data, err := common.Marshal(identity)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(data), nil
+}
+
+func decodePollIdentity(value string) (pollIdentity, error) {
+	data, err := base64.RawURLEncoding.DecodeString(strings.TrimSpace(value))
+	if err != nil {
+		return pollIdentity{}, errors.New("invalid Agnes task identity")
+	}
+	var identity pollIdentity
+	if common.Unmarshal(data, &identity) != nil || strings.TrimSpace(identity.VideoID) == "" ||
+		(identity.Model != ModelVideo25 && identity.Model != ModelVideo25Flash) {
+		return pollIdentity{}, errors.New("invalid Agnes task identity")
+	}
+	return identity, nil
+}
+
+func agnesRoot(baseURL string) string {
+	root := strings.TrimRight(strings.TrimSpace(baseURL), "/")
+	return strings.TrimSuffix(root, "/v1")
+}
+
+func progressString(progress int) string {
+	if progress <= 0 {
+		return taskcommon.ProgressQueued
+	}
+	if progress >= 100 {
+		return taskcommon.ProgressComplete
+	}
+	return fmt.Sprintf("%d%%", progress)
+}
+
+func (response *videoResponse) resultURL() string {
+	if response == nil {
+		return ""
+	}
+	if response.Metadata != nil {
+		if value := strings.TrimSpace(response.Metadata.URL); value != "" {
+			return value
+		}
+	}
+	// Agnes currently returns the completed asset in a top-level `url` field,
+	// while its published schema and some responses use `metadata.url`.
+	return strings.TrimSpace(response.URL)
+}
+
+func (response *videoResponse) errorMessage() string {
+	if response == nil {
+		return ""
+	}
+	if response.Error != nil && strings.TrimSpace(response.Error.Message) != "" {
+		return strings.TrimSpace(response.Error.Message)
+	}
+	if strings.TrimSpace(response.Message) != "" {
+		return strings.TrimSpace(response.Message)
+	}
+	if len(response.Detail) > 0 && string(response.Detail) != "null" {
+		var detail string
+		if common.Unmarshal(response.Detail, &detail) == nil {
+			return strings.TrimSpace(detail)
+		}
+	}
+	return ""
+}
+
+func (response *videoResponse) toOpenAIVideo(publicTaskID, publicModel string) *dto.OpenAIVideo {
+	result := dto.NewOpenAIVideo()
+	result.ID = publicTaskID
+	result.TaskID = publicTaskID
+	result.Model = publicModel
+	switch strings.ToLower(strings.TrimSpace(response.Status)) {
+	case "queued", "pending":
+		result.Status = dto.VideoStatusQueued
+	case "in_progress", "processing", "running":
+		result.Status = dto.VideoStatusInProgress
+	case "completed", "succeeded", "success":
+		result.Status = dto.VideoStatusCompleted
+	case "failed", "cancelled", "canceled":
+		result.Status = dto.VideoStatusFailed
+	default:
+		result.Status = dto.VideoStatusQueued
+	}
+	result.Progress = response.Progress
+	result.CreatedAt = response.CreatedAt
+	if result.CreatedAt == 0 {
+		result.CreatedAt = time.Now().Unix()
+	}
+	result.CompletedAt = response.CompletedAt
+	result.Seconds = response.Seconds
+	result.Size = response.Size
+	if url := response.resultURL(); url != "" {
+		result.SetMetadata("url", url)
+	}
+	return result
+}

--- a/apps/new-api/relay/channel/task/agnes/adaptor_test.go
+++ b/apps/new-api/relay/channel/task/agnes/adaptor_test.go
@@ -1,0 +1,285 @@
+package agnes
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/QuantumNous/new-api/common"
+	"github.com/QuantumNous/new-api/dto"
+	"github.com/QuantumNous/new-api/model"
+	relaycommon "github.com/QuantumNous/new-api/relay/common"
+	"github.com/QuantumNous/new-api/service"
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNormalizeTextRequestDefaultsAndPreservesExplicitZeroSeed(t *testing.T) {
+	t.Parallel()
+	seed := 0
+	n := 1
+	normalized, err := normalizeRequest(relaycommon.TaskSubmitReq{
+		Model:  ModelVideo25,
+		Prompt: "a calm tracking shot",
+		Seed:   &seed,
+		N:      &n,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "text", normalized.mode)
+	require.Equal(t, 5, normalized.request.Duration)
+	require.Equal(t, "720p", normalized.resolution)
+	require.Equal(t, "16:9", normalized.aspectRatio)
+	require.NotNil(t, normalized.request.Seed)
+	require.Zero(t, *normalized.request.Seed)
+}
+
+func TestNormalizeReferenceRequestSupportsAllAgnesMedia(t *testing.T) {
+	t.Parallel()
+	start := 0.0
+	requireAudio := false
+	normalized, err := normalizeRequest(relaycommon.TaskSubmitReq{
+		Model:           ModelVideo25,
+		Prompt:          "use <Picture 1>, <Audio 1>, and <Video 1>",
+		Seconds:         "8",
+		Resolution:      "1080P",
+		AspectRatio:     "9:16",
+		Images:          []string{"https://example.com/image.png"},
+		ReferenceAudios: []string{"https://example.com/audio.mp3"},
+		VideoReferences: []relaycommon.TaskVideoReference{{
+			URL:          "https://example.com/video.mp4",
+			StartSeconds: &start,
+			RequireAudio: &requireAudio,
+		}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, "reference", normalized.mode)
+	require.Equal(t, "1080p", normalized.resolution)
+	require.NotNil(t, normalized.request.VideoReferences[0].StartSeconds)
+	require.Zero(t, *normalized.request.VideoReferences[0].StartSeconds)
+	require.NotNil(t, normalized.request.VideoReferences[0].RequireAudio)
+	require.False(t, *normalized.request.VideoReferences[0].RequireAudio)
+}
+
+func TestNormalizeVideoRequestMapsOpenAIPixelSize(t *testing.T) {
+	t.Parallel()
+	normalized, err := normalizeRequest(relaycommon.TaskSubmitReq{
+		Model:  ModelVideo25,
+		Prompt: "portrait video",
+		Size:   "1080x1920",
+	})
+	require.NoError(t, err)
+	require.Equal(t, "1080p", normalized.resolution)
+	require.Equal(t, "9:16", normalized.aspectRatio)
+}
+
+func TestNormalizeFlashRejectsReferenceVideo(t *testing.T) {
+	t.Parallel()
+	_, err := normalizeRequest(relaycommon.TaskSubmitReq{
+		Model:           ModelVideo25Flash,
+		Prompt:          "reference video",
+		ReferenceVideos: []string{"https://example.com/video.mp4"},
+	})
+	require.ErrorContains(t, err, "videos is not supported")
+}
+
+func TestNormalizeRequestRejectsNonHTTPSMediaReferences(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		name string
+		req  relaycommon.TaskSubmitReq
+		want string
+	}{
+		{
+			name: "data URI first frame",
+			req: relaycommon.TaskSubmitReq{
+				Model:      ModelVideo25,
+				Prompt:     "keyframe",
+				Mode:       "keyframe",
+				StartFrame: "data:image/png;base64,AAAA",
+			},
+			want: "first_frame must be a public HTTPS URL",
+		},
+		{
+			name: "HTTP image",
+			req: relaycommon.TaskSubmitReq{
+				Model:  ModelVideo25Flash,
+				Prompt: "reference",
+				Mode:   "reference",
+				Images: []string{"http://example.com/image.png"},
+			},
+			want: "images[0] must be a public HTTPS URL",
+		},
+		{
+			name: "file ID audio",
+			req: relaycommon.TaskSubmitReq{
+				Model:           ModelVideo25Flash,
+				Prompt:          "reference",
+				Mode:            "reference",
+				ReferenceAudios: []string{"file-audio"},
+			},
+			want: "audios[0] must be a public HTTPS URL",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := normalizeRequest(test.req)
+			require.ErrorContains(t, err, test.want)
+		})
+	}
+}
+
+func TestBuildRequestBodyUsesAgnesWireContract(t *testing.T) {
+	t.Parallel()
+	seed := 0
+	n := 1
+	request := relaycommon.TaskSubmitReq{
+		Model:       ModelVideo25Flash,
+		Prompt:      "a cinematic sunrise",
+		Mode:        "text",
+		Duration:    4,
+		Resolution:  "720p",
+		AspectRatio: "16:9",
+		Seed:        &seed,
+		N:           &n,
+	}
+	context, _ := gin.CreateTestContext(httptest.NewRecorder())
+	relaycommon.SetTaskRequest(context, request)
+	info := &relaycommon.RelayInfo{ChannelMeta: &relaycommon.ChannelMeta{UpstreamModelName: ModelVideo25Flash}}
+	body, err := (&TaskAdaptor{}).BuildRequestBody(context, info)
+	require.NoError(t, err)
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	var payload map[string]interface{}
+	require.NoError(t, common.Unmarshal(data, &payload))
+	require.Equal(t, ModelVideo25Flash, payload["model"])
+	require.Equal(t, "4", payload["seconds"])
+	require.Equal(t, "720P", payload["size"])
+	require.Equal(t, float64(0), payload["seed"])
+	require.Equal(t, float64(1), payload["n"])
+}
+
+func TestFetchTaskUsesAgnesQueryContract(t *testing.T) {
+	service.InitHttpClient()
+	var receivedPath string
+	var receivedQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		receivedPath = request.URL.Path
+		receivedQuery = request.URL.RawQuery
+		require.Equal(t, "Bearer test-key", request.Header.Get("Authorization"))
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"video_id":"video_123","status":"queued"}`))
+	}))
+	defer server.Close()
+
+	encodedID, err := encodePollIdentity("video_123", ModelVideo25Flash)
+	require.NoError(t, err)
+	response, err := (&TaskAdaptor{}).FetchTask(server.URL+"/v1", "test-key", map[string]any{"task_id": encodedID}, "")
+	require.NoError(t, err)
+	_ = response.Body.Close()
+	require.Equal(t, "/agnesapi", receivedPath)
+	query, err := url.ParseQuery(receivedQuery)
+	require.NoError(t, err)
+	require.Equal(t, "video_123", query.Get("video_id"))
+	require.Equal(t, ModelVideo25Flash, query.Get("model_name"))
+}
+
+func TestParseTaskResultExtractsMetadataURL(t *testing.T) {
+	t.Parallel()
+	result, err := (&TaskAdaptor{}).ParseTaskResult([]byte(`{
+		"video_id":"video_123",
+		"status":"completed",
+		"progress":100,
+		"metadata":{"url":"https://example.com/result.mp4"}
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, string(model.TaskStatusSuccess), result.Status)
+	require.Equal(t, "https://example.com/result.mp4", result.Url)
+	require.Equal(t, "100%", result.Progress)
+}
+
+func TestParseTaskResultFallsBackToTopLevelURL(t *testing.T) {
+	t.Parallel()
+	result, err := (&TaskAdaptor{}).ParseTaskResult([]byte(`{
+		"id":"task_upstream",
+		"status":"completed",
+		"progress":100,
+		"url":"https://example.com/live-result.mp4"
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, string(model.TaskStatusSuccess), result.Status)
+	require.Equal(t, "https://example.com/live-result.mp4", result.Url)
+	require.Equal(t, "100%", result.Progress)
+}
+
+func TestDoResponseHidesUpstreamVideoID(t *testing.T) {
+	t.Parallel()
+	recorder := httptest.NewRecorder()
+	context, _ := gin.CreateTestContext(recorder)
+	response := &http.Response{
+		StatusCode: http.StatusOK,
+		Body: io.NopCloser(strings.NewReader(`{
+			"id":"task_upstream",
+			"task_id":"task_upstream",
+			"video_id":"video_secret",
+			"model":"agnes-video-2.5",
+			"status":"queued",
+			"progress":0,
+			"seconds":"5",
+			"size":"720P"
+		}`)),
+	}
+	info := &relaycommon.RelayInfo{
+		OriginModelName: ModelVideo25,
+		TaskRelayInfo:   &relaycommon.TaskRelayInfo{PublicTaskID: "task_public"},
+	}
+	encodedID, _, taskErr := (&TaskAdaptor{}).DoResponse(context, response, info)
+	require.Nil(t, taskErr)
+	require.NotEmpty(t, encodedID)
+	require.Contains(t, recorder.Body.String(), "task_public")
+	require.NotContains(t, recorder.Body.String(), "video_secret")
+	require.NotContains(t, recorder.Body.String(), "task_upstream")
+}
+
+func TestConvertToOpenAIVideoUsesPublicTaskID(t *testing.T) {
+	t.Parallel()
+	task := &model.Task{
+		TaskID:    "task_public",
+		Status:    model.TaskStatusSuccess,
+		Progress:  "100%",
+		CreatedAt: 10,
+		UpdatedAt: 20,
+		Properties: model.Properties{
+			OriginModelName: ModelVideo25,
+		},
+		Data: []byte(`{"video_id":"video_secret","status":"completed","seconds":"5","size":"720P","metadata":{"url":"https://example.com/result.mp4"}}`),
+	}
+	data, err := (&TaskAdaptor{}).ConvertToOpenAIVideo(task)
+	require.NoError(t, err)
+	var response dto.OpenAIVideo
+	require.NoError(t, common.Unmarshal(data, &response))
+	require.Equal(t, "task_public", response.ID)
+	require.Equal(t, "https://example.com/result.mp4", response.Metadata["url"])
+	require.NotContains(t, string(data), "video_secret")
+}
+
+func TestConvertToOpenAIVideoUsesTopLevelResultURL(t *testing.T) {
+	t.Parallel()
+	task := &model.Task{
+		TaskID:   "task_public",
+		Status:   model.TaskStatusSuccess,
+		Progress: "100%",
+		Properties: model.Properties{
+			OriginModelName: ModelVideo25Flash,
+		},
+		Data: []byte(`{"id":"task_upstream","status":"completed","url":"https://example.com/live-result.mp4"}`),
+	}
+	data, err := (&TaskAdaptor{}).ConvertToOpenAIVideo(task)
+	require.NoError(t, err)
+	var response dto.OpenAIVideo
+	require.NoError(t, common.Unmarshal(data, &response))
+	require.Equal(t, "https://example.com/live-result.mp4", response.Metadata["url"])
+	require.NotContains(t, string(data), "task_upstream")
+}

--- a/apps/new-api/relay/common/relay_info.go
+++ b/apps/new-api/relay/common/relay_info.go
@@ -678,13 +678,29 @@ type TaskSubmitReq struct {
 	Images          []string               `json:"images,omitempty"`
 	Urls            []string               `json:"urls,omitempty"`
 	ReferenceImages []string               `json:"referenceImages,omitempty"`
+	ReferenceVideos []string               `json:"referenceVideos,omitempty"`
+	ReferenceAudios []string               `json:"referenceAudios,omitempty"`
+	Audios          []string               `json:"audios,omitempty"`
+	VideoReferences []TaskVideoReference   `json:"videos,omitempty"`
 	Size            string                 `json:"size,omitempty"`
 	Resolution      string                 `json:"resolution,omitempty"`
 	AspectRatio     string                 `json:"aspect_ratio,omitempty"`
 	Duration        int                    `json:"duration,omitempty"`
 	Seconds         string                 `json:"seconds,omitempty"`
 	InputReference  string                 `json:"input_reference,omitempty"`
+	StartFrame      string                 `json:"start_frame,omitempty"`
+	EndFrame        string                 `json:"end_frame,omitempty"`
+	N               *int                   `json:"n,omitempty"`
+	Seed            *int                   `json:"seed,omitempty"`
 	Metadata        map[string]interface{} `json:"metadata,omitempty"`
+}
+
+// TaskVideoReference is a structured reference-video input. Pointer scalar
+// fields preserve explicit zero and false values supplied by clients.
+type TaskVideoReference struct {
+	URL          string   `json:"url"`
+	StartSeconds *float64 `json:"start_seconds,omitempty"`
+	RequireAudio *bool    `json:"require_audio,omitempty"`
 }
 
 func (t *TaskSubmitReq) GetPrompt() string {
@@ -700,7 +716,14 @@ func (t *TaskSubmitReq) UnmarshalJSON(data []byte) error {
 	aux := &struct {
 		Metadata             json.RawMessage `json:"metadata,omitempty"`
 		Duration             json.RawMessage `json:"duration,omitempty"`
+		DurationSeconds      json.RawMessage `json:"duration_seconds,omitempty"`
 		ReferenceImagesSnake json.RawMessage `json:"reference_images,omitempty"`
+		ReferenceVideosSnake json.RawMessage `json:"reference_videos,omitempty"`
+		ReferenceAudiosSnake json.RawMessage `json:"reference_audios,omitempty"`
+		FirstFrameURL        json.RawMessage `json:"first_frame_url,omitempty"`
+		LastFrameURL         json.RawMessage `json:"last_frame_url,omitempty"`
+		FirstFrame           json.RawMessage `json:"first_frame,omitempty"`
+		LastFrame            json.RawMessage `json:"last_frame,omitempty"`
 		AspectRatioCamel     json.RawMessage `json:"aspectRatio,omitempty"`
 		*Alias
 	}{
@@ -711,13 +734,17 @@ func (t *TaskSubmitReq) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	if len(aux.Duration) > 0 {
+	durationRaw := aux.Duration
+	if len(durationRaw) == 0 {
+		durationRaw = aux.DurationSeconds
+	}
+	if len(durationRaw) > 0 {
 		var durationInt int
-		if err := common.Unmarshal(aux.Duration, &durationInt); err == nil {
+		if err := common.Unmarshal(durationRaw, &durationInt); err == nil {
 			t.Duration = durationInt
 		} else {
 			var durationStr string
-			if err := common.Unmarshal(aux.Duration, &durationStr); err == nil && durationStr != "" {
+			if err := common.Unmarshal(durationRaw, &durationStr); err == nil && durationStr != "" {
 				if v, err := strconv.Atoi(durationStr); err == nil {
 					t.Duration = v
 				}
@@ -746,6 +773,24 @@ func (t *TaskSubmitReq) UnmarshalJSON(data []byte) error {
 		if err := common.Unmarshal(aux.ReferenceImagesSnake, &values); err == nil {
 			t.ReferenceImages = values
 		}
+	}
+	if len(t.ReferenceVideos) == 0 && len(aux.ReferenceVideosSnake) > 0 {
+		_ = common.Unmarshal(aux.ReferenceVideosSnake, &t.ReferenceVideos)
+	}
+	if len(t.ReferenceAudios) == 0 && len(aux.ReferenceAudiosSnake) > 0 {
+		_ = common.Unmarshal(aux.ReferenceAudiosSnake, &t.ReferenceAudios)
+	}
+	if strings.TrimSpace(t.StartFrame) == "" && len(aux.FirstFrameURL) > 0 {
+		_ = common.Unmarshal(aux.FirstFrameURL, &t.StartFrame)
+	}
+	if strings.TrimSpace(t.StartFrame) == "" && len(aux.FirstFrame) > 0 {
+		_ = common.Unmarshal(aux.FirstFrame, &t.StartFrame)
+	}
+	if strings.TrimSpace(t.EndFrame) == "" && len(aux.LastFrameURL) > 0 {
+		_ = common.Unmarshal(aux.LastFrameURL, &t.EndFrame)
+	}
+	if strings.TrimSpace(t.EndFrame) == "" && len(aux.LastFrame) > 0 {
+		_ = common.Unmarshal(aux.LastFrame, &t.EndFrame)
 	}
 
 	if strings.TrimSpace(t.AspectRatio) == "" && len(aux.AspectRatioCamel) > 0 {

--- a/apps/new-api/relay/common/relay_utils.go
+++ b/apps/new-api/relay/common/relay_utils.go
@@ -261,14 +261,36 @@ func ValidateMultipartDirect(c *gin.Context, info *RelayInfo) *dto.TaskError {
 
 func isKnownTaskField(field string) bool {
 	knownFields := map[string]bool{
-		"prompt":          true,
-		"model":           true,
-		"mode":            true,
-		"image":           true,
-		"images":          true,
-		"size":            true,
-		"duration":        true,
-		"input_reference": true, // Sora 特有字段
+		"prompt":           true,
+		"model":            true,
+		"mode":             true,
+		"image":            true,
+		"images":           true,
+		"urls":             true,
+		"referenceImages":  true,
+		"reference_images": true,
+		"referenceVideos":  true,
+		"reference_videos": true,
+		"referenceAudios":  true,
+		"reference_audios": true,
+		"audios":           true,
+		"videos":           true,
+		"size":             true,
+		"resolution":       true,
+		"aspect_ratio":     true,
+		"aspectRatio":      true,
+		"duration":         true,
+		"duration_seconds": true,
+		"seconds":          true,
+		"input_reference":  true, // Sora 特有字段
+		"start_frame":      true,
+		"end_frame":        true,
+		"first_frame":      true,
+		"last_frame":       true,
+		"first_frame_url":  true,
+		"last_frame_url":   true,
+		"n":                true,
+		"seed":             true,
 	}
 	return knownFields[field]
 }

--- a/apps/new-api/relay/common/relay_utils_test.go
+++ b/apps/new-api/relay/common/relay_utils_test.go
@@ -82,6 +82,41 @@ func TestTaskSubmitReqUnmarshalSupportsSnakeAndCamelAliases(t *testing.T) {
 	require.Equal(t, "9:16", req.Metadata["aspect_ratio"])
 }
 
+func TestTaskSubmitReqAcceptsAgnesMediaFieldsAndPreservesZeroValues(t *testing.T) {
+	t.Parallel()
+
+	var request TaskSubmitReq
+	err := neoSparkMartcommon.Unmarshal([]byte(`{
+		"model":"agnes-video-2.5",
+		"prompt":"test",
+		"duration_seconds":9,
+		"first_frame":"https://example.com/first.png",
+		"last_frame":"https://example.com/last.png",
+		"reference_videos":["https://example.com/reference.mp4"],
+		"reference_audios":["https://example.com/reference.mp3"],
+		"audios":["https://example.com/audio.mp3"],
+		"videos":[{"url":"https://example.com/video.mp4","start_seconds":0,"require_audio":false}],
+		"seed":0,
+		"n":1
+	}`), &request)
+	require.NoError(t, err)
+	require.Equal(t, 9, request.Duration)
+	require.Equal(t, "https://example.com/first.png", request.StartFrame)
+	require.Equal(t, "https://example.com/last.png", request.EndFrame)
+	require.Equal(t, []string{"https://example.com/reference.mp4"}, request.ReferenceVideos)
+	require.Equal(t, []string{"https://example.com/reference.mp3"}, request.ReferenceAudios)
+	require.Equal(t, []string{"https://example.com/audio.mp3"}, request.Audios)
+	require.Len(t, request.VideoReferences, 1)
+	require.NotNil(t, request.VideoReferences[0].StartSeconds)
+	require.Zero(t, *request.VideoReferences[0].StartSeconds)
+	require.NotNil(t, request.VideoReferences[0].RequireAudio)
+	require.False(t, *request.VideoReferences[0].RequireAudio)
+	require.NotNil(t, request.Seed)
+	require.Zero(t, *request.Seed)
+	require.NotNil(t, request.N)
+	require.Equal(t, 1, *request.N)
+}
+
 func TestNormalizeTaskSubmitReqIncludesInputReference(t *testing.T) {
 	t.Parallel()
 

--- a/apps/new-api/relay/relay_adaptor.go
+++ b/apps/new-api/relay/relay_adaptor.go
@@ -4,6 +4,7 @@ import (
 	"github.com/QuantumNous/new-api/common"
 	"github.com/QuantumNous/new-api/constant"
 	"github.com/QuantumNous/new-api/relay/channel"
+	"github.com/QuantumNous/new-api/relay/channel/agnes"
 	"github.com/QuantumNous/new-api/relay/channel/ali"
 	"github.com/QuantumNous/new-api/relay/channel/amux"
 	"github.com/QuantumNous/new-api/relay/channel/apimart"
@@ -39,6 +40,7 @@ import (
 	"github.com/QuantumNous/new-api/relay/channel/runninghub"
 	"github.com/QuantumNous/new-api/relay/channel/siliconflow"
 	"github.com/QuantumNous/new-api/relay/channel/submodel"
+	taskagnes "github.com/QuantumNous/new-api/relay/channel/task/agnes"
 	taskali "github.com/QuantumNous/new-api/relay/channel/task/ali"
 	taskapimart "github.com/QuantumNous/new-api/relay/channel/task/apimart"
 	taskdoubao "github.com/QuantumNous/new-api/relay/channel/task/doubao"
@@ -161,6 +163,8 @@ func GetAdaptor(apiType int) channel.Adaptor {
 		return &kiro.Adaptor{}
 	case constant.APITypeFlow2API:
 		return &openai.Adaptor{}
+	case constant.APITypeAgnes:
+		return &agnes.Adaptor{}
 	}
 	return nil
 }
@@ -213,6 +217,8 @@ func GetTaskAdaptor(platform constant.TaskPlatform) channel.TaskAdaptor {
 		return &taskmagic666.TaskAdaptor{}
 	case constant.TaskPlatformMediaKit:
 		return &taskvolcmediakit.TaskAdaptor{}
+	case constant.TaskPlatformAgnes:
+		return &taskagnes.TaskAdaptor{}
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary

- add Agnes Image 2.5 Flash support through the standard OpenAI Images endpoint
- add Agnes Video 2.5 and Video 2.5 Flash task submission, polling, validation, and response conversion
- preserve explicit zero/false request values and accept common frame/media aliases
- register separate image and asynchronous video protocols with the Agnes default endpoint

## Validation

- `go test -count=1 ./constant ./relay/common ./relay/channel/agnes ./relay/channel/task/agnes ./relay`

## Scope

This contribution intentionally excludes deployment configuration, pricing policy, private model aliases/catalogs, credentials, and vendor-routing preferences.